### PR TITLE
Remove IfMissing.Fallback

### DIFF
--- a/librarymanagement/src/main/scala/sbt/internal/librarymanagement/ComponentManager.scala
+++ b/librarymanagement/src/main/scala/sbt/internal/librarymanagement/ComponentManager.scala
@@ -41,8 +41,6 @@ class ComponentManager(globalLock: xsbti.GlobalLock, provider: xsbti.ComponentPr
             d()
             if (d.cache) cache(id)
             getOrElse(notFound)
-          case f: IfMissing.Fallback =>
-            f()
         }
 
       lockLocalCache { getOrElse(fromGlobal) }
@@ -77,7 +75,6 @@ sealed trait IfMissing
 object IfMissing {
   object Fail extends IfMissing
   final class Define(val cache: Boolean, define: => Unit) extends IfMissing { def apply() = define }
-  final class Fallback(f: => Iterable[File]) extends IfMissing { def apply() = f }
 }
 object ComponentManager {
   lazy val (version, timestamp) =


### PR DESCRIPTION
It was used by code in ComponentCompiler in sbt/incrementalcompiler, but
this code has been removed.

(This change was originally introduced in sbt/sbt#2197)
