### PR TITLE
add toString to UpdateOptions

### DIFF
--- a/librarymanagement/src/main/scala/sbt/librarymanagement/UpdateOptions.scala
+++ b/librarymanagement/src/main/scala/sbt/librarymanagement/UpdateOptions.scala
@@ -1,6 +1,5 @@
 package sbt.librarymanagement
 
-import java.io.File
 import org.apache.ivy.plugins.resolver.DependencyResolver
 import org.apache.ivy.core.settings.IvySettings
 import sbt.util.Logger
@@ -49,6 +48,14 @@ final class UpdateOptions private[sbt] (
       consolidatedResolution,
       cachedResolution,
       resolverConverter)
+
+  override def toString(): String =
+    s"""UpdateOptions(
+        |  circularDependencyLevel = $circularDependencyLevel,
+        |  latestSnapshots = $latestSnapshots,
+        |  consolidatedResolution = $consolidatedResolution,
+        |  cachedResolution = $cachedResolution
+        |)""".stripMargin
 
   override def equals(o: Any): Boolean = o match {
     case o: UpdateOptions =>

--- a/librarymanagement/src/test/scala/UpdateOptionsSpec.scala
+++ b/librarymanagement/src/test/scala/UpdateOptionsSpec.scala
@@ -1,0 +1,27 @@
+package sbt.librarymanagement
+
+import sbt.internal.util.UnitSpec
+
+class UpdateOptionsSpec extends UnitSpec {
+
+  "UpdateOptions" should "have proper toString defined" in {
+    UpdateOptions().toString() should be(
+      """|UpdateOptions(
+        |  circularDependencyLevel = warn,
+        |  latestSnapshots = false,
+        |  consolidatedResolution = false,
+        |  cachedResolution = false
+        |)""".stripMargin)
+
+    UpdateOptions()
+      .withCircularDependencyLevel(CircularDependencyLevel.Error)
+      .withCachedResolution(true)
+      .withLatestSnapshots(true).toString() should be(
+      """|UpdateOptions(
+        |  circularDependencyLevel = error,
+        |  latestSnapshots = true,
+        |  consolidatedResolution = false,
+        |  cachedResolution = true
+        |)""".stripMargin)
+  }
+}


### PR DESCRIPTION
as of 0.13.9 there is no an easy way to see updateOptions attributes

'[info]     sbt.UpdateOptions@f5a7a399'
