### PR TITLE
Don't warn on inconsistent versions in different configurations

### DIFF
--- a/librarymanagement/src/main/scala/sbt/internal/librarymanagement/Ivy.scala
+++ b/librarymanagement/src/main/scala/sbt/internal/librarymanagement/Ivy.scala
@@ -529,14 +529,18 @@ private[sbt] object IvySbt {
     {
       import IvyRetrieve.toModuleID
       val dds = moduleID.getDependencies
-      inconsistentDuplicateWarning(dds map { dd => toModuleID(dd.getDependencyRevisionId) })
+      val deps = dds flatMap { dd =>
+        val module = toModuleID(dd.getDependencyRevisionId)
+        dd.getModuleConfigurations map (c => module.copy(configurations = Some(c)))
+      }
+      inconsistentDuplicateWarning(deps)
     }
 
   def inconsistentDuplicateWarning(dependencies: Seq[ModuleID]): List[String] =
     {
       val warningHeader = "Multiple dependencies with the same organization/name but different versions. To avoid conflict, pick one version:"
       val out: mutable.ListBuffer[String] = mutable.ListBuffer()
-      (dependencies groupBy { dep => (dep.organization, dep.name) }) foreach {
+      (dependencies groupBy { dep => (dep.organization, dep.name, dep.configurations) }) foreach {
         case (k, vs) if vs.size > 1 =>
           val v0 = vs.head
           (vs find { _.revision != v0.revision }) foreach { v =>

--- a/librarymanagement/src/test/scala/InconsistentDuplicateSpec.scala
+++ b/librarymanagement/src/test/scala/InconsistentDuplicateSpec.scala
@@ -13,6 +13,10 @@ class InconsistentDuplicateSpec extends UnitSpec {
       )
   }
 
+  it should "not be warned if in different configurations" in {
+    IvySbt.inconsistentDuplicateWarning(Seq(akkaActor214, akkaActor230Test)) shouldBe Nil
+  }
+
   "Duplicate with same version" should "not be warned" in {
     IvySbt.inconsistentDuplicateWarning(Seq(akkaActor230Test, akkaActor230)) shouldBe Nil
   }


### PR DESCRIPTION
(This is a port of sbt/sbt#2258)

sbt was reporting warning abouts inconsistent versions of dependencies
even if these dependencies didn't have the same configuration (as in
`provided` vs `compile`).

This commit fixes this problem by comparing the dependencies by
organization, artifact name and configuration.
