### PR TITLE
FPORT: Make sbt aware of Dotty

### DIFF
--- a/librarymanagement/src/main/scala/sbt/librarymanagement/IvyScala.scala
+++ b/librarymanagement/src/main/scala/sbt/librarymanagement/IvyScala.scala
@@ -17,12 +17,20 @@ object ScalaArtifacts {
   val LibraryID = "scala-library"
   val CompilerID = "scala-compiler"
   val ReflectID = "scala-reflect"
+  val DottyIDPrefix = "dotty"
+
+  def dottyID(binaryVersion: String): String = s"${DottyIDPrefix}_${binaryVersion}"
+
   def libraryDependency(version: String): ModuleID = ModuleID(Organization, LibraryID, version)
 
-  private[sbt] def toolDependencies(org: String, version: String): Seq[ModuleID] = Seq(
-    scalaToolDependency(org, ScalaArtifacts.CompilerID, version),
-    scalaToolDependency(org, ScalaArtifacts.LibraryID, version)
-  )
+  private[sbt] def toolDependencies(org: String, version: String, isDotty: Boolean = false): Seq[ModuleID] =
+    if (isDotty)
+      Seq(ModuleID(org, DottyIDPrefix, version, Some(Configurations.ScalaTool.name + "->compile"),
+        crossVersion = CrossVersion.binary))
+    else
+      Seq(scalaToolDependency(org, ScalaArtifacts.CompilerID, version),
+        scalaToolDependency(org, ScalaArtifacts.LibraryID, version))
+
   private[this] def scalaToolDependency(org: String, id: String, version: String): ModuleID =
     ModuleID(org, id, version, Some(Configurations.ScalaTool.name + "->default,optional(default)"))
 }


### PR DESCRIPTION
This small set of changes, together with the compiler-bridge I wrote
(https://github.com/smarter/dotty-bridge) enables us to compile code
using Dotty in sbt, see https://github.com/smarter/dotty-example-project
for an example.

Partial forward port of sbt/sbt#2344.
