### PR TITLE
Rename InlineConfigurationWithExcludes -> InlineConfiguration

### DIFF
--- a/librarymanagement/src/main/scala/sbt/internal/librarymanagement/CompatibilityWarning.scala
+++ b/librarymanagement/src/main/scala/sbt/internal/librarymanagement/CompatibilityWarning.scala
@@ -32,8 +32,8 @@ private[sbt] object CompatibilityWarning {
   def processIntransitive(config: CompatibilityWarningOptions, module: IvySbt#Module, log: Logger): Unit = {
     val monitoredConfigsStr: Set[String] = (config.configurations map { _.name }).toSet
     val directDependencies: Seq[ModuleID] = module.moduleSettings match {
-      case x: InlineConfigurationWithExcludes => x.dependencies
-      case _                                  => Seq()
+      case x: InlineConfiguration => x.dependencies
+      case _                      => Seq()
     }
     def inMonitoredConfigs(configOpt: Option[String]): Boolean =
       configOpt match {

--- a/librarymanagement/src/main/scala/sbt/internal/librarymanagement/CompatibilityWarning.scala
+++ b/librarymanagement/src/main/scala/sbt/internal/librarymanagement/CompatibilityWarning.scala
@@ -32,7 +32,6 @@ private[sbt] object CompatibilityWarning {
   def processIntransitive(config: CompatibilityWarningOptions, module: IvySbt#Module, log: Logger): Unit = {
     val monitoredConfigsStr: Set[String] = (config.configurations map { _.name }).toSet
     val directDependencies: Seq[ModuleID] = module.moduleSettings match {
-      case x: InlineConfiguration             => x.dependencies
       case x: InlineConfigurationWithExcludes => x.dependencies
       case _                                  => Seq()
     }

--- a/librarymanagement/src/main/scala/sbt/internal/librarymanagement/Ivy.scala
+++ b/librarymanagement/src/main/scala/sbt/internal/librarymanagement/Ivy.scala
@@ -170,7 +170,6 @@ final class IvySbt(val configuration: IvyConfiguration) {
       {
         val (baseModule, baseConfiguration) =
           moduleSettings match {
-            case ic: InlineConfiguration             => configureInline(ic.withExcludes, configuration.log)
             case ic: InlineConfigurationWithExcludes => configureInline(ic, configuration.log)
             case pc: PomConfiguration                => configurePom(pc)
             case ifc: IvyFileConfiguration           => configureIvyFile(ifc)
@@ -435,7 +434,6 @@ private[sbt] object IvySbt {
     {
       val sub = CrossVersion(scalaFullVersion, scalaBinaryVersion)
       m match {
-        case ic: InlineConfiguration             => ic.copy(module = sub(ic.module), dependencies = ic.dependencies map sub, overrides = ic.overrides map sub)
         case ic: InlineConfigurationWithExcludes => ic.copy(module = sub(ic.module), dependencies = ic.dependencies map sub, overrides = ic.overrides map sub)
         case _                                   => m
       }

--- a/librarymanagement/src/main/scala/sbt/internal/librarymanagement/Ivy.scala
+++ b/librarymanagement/src/main/scala/sbt/internal/librarymanagement/Ivy.scala
@@ -170,15 +170,15 @@ final class IvySbt(val configuration: IvyConfiguration) {
       {
         val (baseModule, baseConfiguration) =
           moduleSettings match {
-            case ic: InlineConfigurationWithExcludes => configureInline(ic, configuration.log)
-            case pc: PomConfiguration                => configurePom(pc)
-            case ifc: IvyFileConfiguration           => configureIvyFile(ifc)
+            case ic: InlineConfiguration   => configureInline(ic, configuration.log)
+            case pc: PomConfiguration      => configurePom(pc)
+            case ifc: IvyFileConfiguration => configureIvyFile(ifc)
           }
         moduleSettings.ivyScala.foreach(IvyScala.checkModule(baseModule, baseConfiguration, configuration.log))
         IvySbt.addExtraNamespace(baseModule)
         (baseModule, baseConfiguration)
       }
-    private def configureInline(ic: InlineConfigurationWithExcludes, log: Logger) =
+    private def configureInline(ic: InlineConfiguration, log: Logger) =
       {
         import ic._
         val moduleID = newConfiguredModuleID(module, moduleInfo, configurations)
@@ -434,8 +434,8 @@ private[sbt] object IvySbt {
     {
       val sub = CrossVersion(scalaFullVersion, scalaBinaryVersion)
       m match {
-        case ic: InlineConfigurationWithExcludes => ic.copy(module = sub(ic.module), dependencies = ic.dependencies map sub, overrides = ic.overrides map sub)
-        case _                                   => m
+        case ic: InlineConfiguration => ic.copy(module = sub(ic.module), dependencies = ic.dependencies map sub, overrides = ic.overrides map sub)
+        case _                       => m
       }
     }
 

--- a/librarymanagement/src/main/scala/sbt/internal/librarymanagement/IvyActions.scala
+++ b/librarymanagement/src/main/scala/sbt/internal/librarymanagement/IvyActions.scala
@@ -148,8 +148,8 @@ object IvyActions {
     }
   private def crossVersionMap(moduleSettings: ModuleSettings): Option[String => String] =
     moduleSettings match {
-      case i: InlineConfigurationWithExcludes => CrossVersion(i.module, i.ivyScala)
-      case _                                  => None
+      case i: InlineConfiguration => CrossVersion(i.module, i.ivyScala)
+      case _                      => None
     }
   def mapArtifacts(module: ModuleDescriptor, cross: Option[String => String], artifacts: Map[Artifact, File]): Seq[(IArtifact, File)] =
     {
@@ -236,7 +236,7 @@ object IvyActions {
       import config.{ configuration => c, ivyScala, module => mod }
       import mod.{ id, modules => deps }
       val base = restrictedCopy(id, true).copy(name = id.name + "$" + label)
-      val module = new ivySbt.Module(InlineConfigurationWithExcludes(base, ModuleInfo(base.name), deps).copy(ivyScala = ivyScala))
+      val module = new ivySbt.Module(InlineConfiguration(base, ModuleInfo(base.name), deps).copy(ivyScala = ivyScala))
       val report = updateEither(module, c, uwconfig, logicalClock, depDir, log) match {
         case Right(r) => r
         case Left(w) =>
@@ -271,7 +271,7 @@ object IvyActions {
       // Adding list of explicit artifacts here.
       val deps = baseModules.distinct flatMap classifiedArtifacts(classifiers, exclude, artifacts)
       val base = restrictedCopy(id, true).copy(name = id.name + classifiers.mkString("$", "_", ""))
-      val module = new ivySbt.Module(InlineConfigurationWithExcludes(base, ModuleInfo(base.name), deps).copy(ivyScala = ivyScala, configurations = confs))
+      val module = new ivySbt.Module(InlineConfiguration(base, ModuleInfo(base.name), deps).copy(ivyScala = ivyScala, configurations = confs))
       // c.copy ensures c.types is preserved too
       val upConf = c.copy(missingOk = true)
       updateEither(module, upConf, uwconfig, logicalClock, depDir, log) match {

--- a/librarymanagement/src/main/scala/sbt/internal/librarymanagement/IvyActions.scala
+++ b/librarymanagement/src/main/scala/sbt/internal/librarymanagement/IvyActions.scala
@@ -148,7 +148,6 @@ object IvyActions {
     }
   private def crossVersionMap(moduleSettings: ModuleSettings): Option[String => String] =
     moduleSettings match {
-      case i: InlineConfiguration             => CrossVersion(i.module, i.ivyScala)
       case i: InlineConfigurationWithExcludes => CrossVersion(i.module, i.ivyScala)
       case _                                  => None
     }

--- a/librarymanagement/src/main/scala/sbt/internal/librarymanagement/IvyConfigurations.scala
+++ b/librarymanagement/src/main/scala/sbt/internal/librarymanagement/IvyConfigurations.scala
@@ -115,8 +115,7 @@ final case class PomConfiguration(file: File, ivyScala: Option[IvyScala], valida
   def noScala = copy(ivyScala = None)
 }
 
-
-final class InlineConfigurationWithExcludes private[sbt] (
+final class InlineConfiguration private[sbt] (
   val module: ModuleID,
   val moduleInfo: ModuleInfo,
   val dependencies: Seq[ModuleID],
@@ -146,16 +145,16 @@ final class InlineConfigurationWithExcludes private[sbt] (
     ivyScala: Option[IvyScala] = this.ivyScala,
     validate: Boolean = this.validate,
     conflictManager: ConflictManager = this.conflictManager
-  ): InlineConfigurationWithExcludes =
-    InlineConfigurationWithExcludes(module, moduleInfo, dependencies, overrides, excludes, ivyXML,
+  ): InlineConfiguration =
+    InlineConfiguration(module, moduleInfo, dependencies, overrides, excludes, ivyXML,
       configurations, defaultConfiguration, ivyScala, validate, conflictManager)
 
   override def toString: String =
-    s"InlineConfigurationWithExcludes($module, $moduleInfo, $dependencies, $overrides, $excludes, " +
+    s"InlineConfiguration($module, $moduleInfo, $dependencies, $overrides, $excludes, " +
       s"$ivyXML, $configurations, $defaultConfiguration, $ivyScala, $validate, $conflictManager)"
 
   override def equals(o: Any): Boolean = o match {
-    case o: InlineConfigurationWithExcludes =>
+    case o: InlineConfiguration =>
       this.module == o.module &&
         this.moduleInfo == o.moduleInfo &&
         this.dependencies == o.dependencies &&
@@ -186,7 +185,7 @@ final class InlineConfigurationWithExcludes private[sbt] (
       hash
     }
 }
-object InlineConfigurationWithExcludes {
+object InlineConfiguration {
   def apply(
     module: ModuleID,
     moduleInfo: ModuleInfo,
@@ -199,8 +198,8 @@ object InlineConfigurationWithExcludes {
     ivyScala: Option[IvyScala] = None,
     validate: Boolean = false,
     conflictManager: ConflictManager = ConflictManager.default
-  ): InlineConfigurationWithExcludes =
-    new InlineConfigurationWithExcludes(module, moduleInfo, dependencies, overrides, excludes, ivyXML,
+  ): InlineConfiguration =
+    new InlineConfiguration(module, moduleInfo, dependencies, overrides, excludes, ivyXML,
       configurations, defaultConfiguration, ivyScala, validate, conflictManager)
 
   def configurations(explicitConfigurations: Iterable[Configuration], defaultConfiguration: Option[Configuration]) =

--- a/librarymanagement/src/main/scala/sbt/internal/librarymanagement/IvyConfigurations.scala
+++ b/librarymanagement/src/main/scala/sbt/internal/librarymanagement/IvyConfigurations.scala
@@ -115,29 +115,6 @@ final case class PomConfiguration(file: File, ivyScala: Option[IvyScala], valida
   def noScala = copy(ivyScala = None)
 }
 
-// TODO: When we go sbt 1.0 we should rename InlineConfigurationWithExcludes to InlineConfiguration.
-@deprecated("Use InlineConfigurationWithExcludes.", "0.13.8")
-final case class InlineConfiguration(module: ModuleID, moduleInfo: ModuleInfo, dependencies: Seq[ModuleID], overrides: Set[ModuleID] = Set.empty, ivyXML: NodeSeq = NodeSeq.Empty, configurations: Seq[Configuration] = Nil, defaultConfiguration: Option[Configuration] = None, ivyScala: Option[IvyScala] = None, validate: Boolean = false, conflictManager: ConflictManager = ConflictManager.default) extends ModuleSettings {
-  def withConfigurations(configurations: Seq[Configuration]) = copy(configurations = configurations)
-  def noScala = copy(ivyScala = None)
-  def withExcludes: InlineConfigurationWithExcludes =
-    InlineConfigurationWithExcludes(this.module, this.moduleInfo, this.dependencies, this.overrides, Nil, this.ivyXML,
-      this.configurations, this.defaultConfiguration, this.ivyScala, this.validate, this.conflictManager)
-  def withOverrides(overrides: Set[ModuleID]): ModuleSettings =
-    copy(overrides = overrides)
-}
-object InlineConfiguration {
-  @deprecated("Use InlineConfigurationWithExcludes.explicitConfigurations.", "0.13.8")
-  def configurations(explicitConfigurations: Iterable[Configuration], defaultConfiguration: Option[Configuration]) =
-    if (explicitConfigurations.isEmpty) {
-      defaultConfiguration match {
-        case Some(Configurations.DefaultIvyConfiguration) => Configurations.Default :: Nil
-        case Some(Configurations.DefaultMavenConfiguration) => Configurations.defaultMavenConfigurations
-        case _ => Nil
-      }
-    } else
-      explicitConfigurations
-}
 
 final class InlineConfigurationWithExcludes private[sbt] (
   val module: ModuleID,

--- a/librarymanagement/src/main/scala/sbt/librarymanagement/EvictionWarning.scala
+++ b/librarymanagement/src/main/scala/sbt/librarymanagement/EvictionWarning.scala
@@ -5,7 +5,7 @@ import Configurations.Compile
 import ScalaArtifacts.{ LibraryID, CompilerID }
 import sbt.util.Logger
 import sbt.internal.util.ShowLines
-import sbt.internal.librarymanagement.{ IvySbt, InlineConfiguration, InlineConfigurationWithExcludes }
+import sbt.internal.librarymanagement.{ IvySbt, InlineConfigurationWithExcludes }
 
 final class EvictionWarningOptions private[sbt] (
   val configurations: Seq[Configuration],
@@ -167,7 +167,6 @@ object EvictionWarning {
 
   private[sbt] def processEvictions(module: IvySbt#Module, options: EvictionWarningOptions, reports: Seq[OrganizationArtifactReport]): EvictionWarning = {
     val directDependencies = module.moduleSettings match {
-      case x: InlineConfiguration             => x.dependencies
       case x: InlineConfigurationWithExcludes => x.dependencies
       case _                                  => Seq()
     }

--- a/librarymanagement/src/main/scala/sbt/librarymanagement/EvictionWarning.scala
+++ b/librarymanagement/src/main/scala/sbt/librarymanagement/EvictionWarning.scala
@@ -5,7 +5,7 @@ import Configurations.Compile
 import ScalaArtifacts.{ LibraryID, CompilerID }
 import sbt.util.Logger
 import sbt.internal.util.ShowLines
-import sbt.internal.librarymanagement.{ IvySbt, InlineConfigurationWithExcludes }
+import sbt.internal.librarymanagement.{ InlineConfiguration, IvySbt }
 
 final class EvictionWarningOptions private[sbt] (
   val configurations: Seq[Configuration],
@@ -167,8 +167,8 @@ object EvictionWarning {
 
   private[sbt] def processEvictions(module: IvySbt#Module, options: EvictionWarningOptions, reports: Seq[OrganizationArtifactReport]): EvictionWarning = {
     val directDependencies = module.moduleSettings match {
-      case x: InlineConfigurationWithExcludes => x.dependencies
-      case _                                  => Seq()
+      case x: InlineConfiguration => x.dependencies
+      case _                      => Seq()
     }
     val pairs = reports map { detail =>
       val evicteds = detail.modules filter { _.evicted }

--- a/librarymanagement/src/test/scala/BaseIvySpecification.scala
+++ b/librarymanagement/src/test/scala/BaseIvySpecification.scala
@@ -33,7 +33,7 @@ trait BaseIvySpecification extends UnitSpec {
       )
     }
 
-    val moduleSetting: ModuleSettings = InlineConfiguration(
+    val moduleSetting: ModuleSettings = InlineConfigurationWithExcludes(
       module = moduleId,
       moduleInfo = ModuleInfo("foo"),
       dependencies = deps,

--- a/librarymanagement/src/test/scala/BaseIvySpecification.scala
+++ b/librarymanagement/src/test/scala/BaseIvySpecification.scala
@@ -33,7 +33,7 @@ trait BaseIvySpecification extends UnitSpec {
       )
     }
 
-    val moduleSetting: ModuleSettings = InlineConfigurationWithExcludes(
+    val moduleSetting: ModuleSettings = InlineConfiguration(
       module = moduleId,
       moduleInfo = ModuleInfo("foo"),
       dependencies = deps,


### PR DESCRIPTION
This long-named class is no longer required, and it only exists so that `InlineConfiguration` could remain backwards-compatible with `0.13`, which is no longer necessary here.
