### PR TITLE
Allow customizing defaultConfMapping in InlineConfiguration

### DIFF
--- a/librarymanagement/src/main/scala/sbt/internal/librarymanagement/CustomXmlParser.scala
+++ b/librarymanagement/src/main/scala/sbt/internal/librarymanagement/CustomXmlParser.scala
@@ -15,8 +15,10 @@ import sbt.librarymanagement._
 
 /** Subclasses the default Ivy file parser in order to provide access to protected methods.*/
 private[sbt] object CustomXmlParser extends XmlModuleDescriptorParser {
+  private val DEFAULT_CONF_MAPPING = "*->default(compile)"
+
   import XmlModuleDescriptorParser.Parser
-  class CustomParser(settings: IvySettings, defaultConfig: Option[String]) extends Parser(CustomXmlParser, settings) {
+  class CustomParser(settings: IvySettings, defaultConfig: Option[String], defaultConfMapping: Option[String]) extends Parser(CustomXmlParser, settings) {
     def setSource(url: URL) =
       {
         super.setResource(new URLResource(url))
@@ -28,7 +30,9 @@ private[sbt] object CustomXmlParser extends XmlModuleDescriptorParser {
     override def setMd(md: DefaultModuleDescriptor) =
       {
         super.setMd(md)
-        if (defaultConfig.isDefined) setDefaultConfMapping("*->default(compile)")
+        if (defaultConfig.isDefined) {
+          setDefaultConfMapping(defaultConfMapping getOrElse DEFAULT_CONF_MAPPING)
+        }
       }
     override def parseDepsConfs(confs: String, dd: DefaultDependencyDescriptor) = super.parseDepsConfs(confs, dd)
     override def getDefaultConf = defaultConfig.getOrElse(super.getDefaultConf)

--- a/librarymanagement/src/main/scala/sbt/internal/librarymanagement/Ivy.scala
+++ b/librarymanagement/src/main/scala/sbt/internal/librarymanagement/Ivy.scala
@@ -186,7 +186,7 @@ final class IvySbt(val configuration: IvyConfiguration) {
         val defaultConf = defaultConfiguration getOrElse Configurations.config(ModuleDescriptor.DEFAULT_CONFIGURATION)
         log.debug("Using inline dependencies specified in Scala" + (if (ivyXML.isEmpty) "." else " and XML."))
 
-        val parser = IvySbt.parseIvyXML(ivy.getSettings, IvySbt.wrapped(module, ivyXML), moduleID, defaultConf.name, validate)
+        val parser = IvySbt.parseIvyXML(ivy.getSettings, IvySbt.wrapped(module, ivyXML), moduleID, defaultConf.name, defaultConfMapping, validate)
         IvySbt.addMainArtifact(moduleID)
         IvySbt.addOverrides(moduleID, overrides, ivy.getSettings.getMatcher(PatternMatcher.EXACT))
         IvySbt.addExcludes(moduleID, excludes, ivyScala)
@@ -214,7 +214,7 @@ final class IvySbt(val configuration: IvyConfiguration) {
         IvySbt.addConfigurations(dmd, Configurations.defaultInternal)
         val defaultConf = Configurations.DefaultMavenConfiguration.name
         for (is <- pc.ivyScala) if (pc.autoScalaTools) {
-          val confParser = new CustomXmlParser.CustomParser(settings, Some(defaultConf))
+          val confParser = new CustomXmlParser.CustomParser(settings, Some(defaultConf), None)
           confParser.setMd(dmd)
           addScalaToolDependencies(dmd, confParser, is)
         }
@@ -223,7 +223,7 @@ final class IvySbt(val configuration: IvyConfiguration) {
     /** Parses the Ivy file 'ivyFile' from the given `IvyFileConfiguration`.*/
     private def configureIvyFile(ifc: IvyFileConfiguration) =
       {
-        val parser = new CustomXmlParser.CustomParser(settings, None)
+        val parser = new CustomXmlParser.CustomParser(settings, None, None)
         parser.setValidate(ifc.validate)
         parser.setSource(toURL(ifc.file))
         parser.parse()
@@ -512,12 +512,12 @@ private[sbt] object IvySbt {
       info.nonEmpty
     }
   /** Parses the given in-memory Ivy file 'xml', using the existing 'moduleID' and specifying the given 'defaultConfiguration'. */
-  private def parseIvyXML(settings: IvySettings, xml: scala.xml.NodeSeq, moduleID: DefaultModuleDescriptor, defaultConfiguration: String, validate: Boolean): CustomXmlParser.CustomParser =
-    parseIvyXML(settings, xml.toString, moduleID, defaultConfiguration, validate)
+  private def parseIvyXML(settings: IvySettings, xml: scala.xml.NodeSeq, moduleID: DefaultModuleDescriptor, defaultConfiguration: String, defaultConfMapping: Option[String], validate: Boolean): CustomXmlParser.CustomParser =
+    parseIvyXML(settings, xml.toString, moduleID, defaultConfiguration, defaultConfMapping, validate)
   /** Parses the given in-memory Ivy file 'xml', using the existing 'moduleID' and specifying the given 'defaultConfiguration'. */
-  private def parseIvyXML(settings: IvySettings, xml: String, moduleID: DefaultModuleDescriptor, defaultConfiguration: String, validate: Boolean): CustomXmlParser.CustomParser =
+  private def parseIvyXML(settings: IvySettings, xml: String, moduleID: DefaultModuleDescriptor, defaultConfiguration: String, defaultConfMapping: Option[String], validate: Boolean): CustomXmlParser.CustomParser =
     {
-      val parser = new CustomXmlParser.CustomParser(settings, Some(defaultConfiguration))
+      val parser = new CustomXmlParser.CustomParser(settings, Some(defaultConfiguration), defaultConfMapping)
       parser.setMd(moduleID)
       parser.setValidate(validate)
       parser.setInput(xml.getBytes)

--- a/librarymanagement/src/main/scala/sbt/internal/librarymanagement/IvyConfigurations.scala
+++ b/librarymanagement/src/main/scala/sbt/internal/librarymanagement/IvyConfigurations.scala
@@ -126,7 +126,8 @@ final class InlineConfiguration private[sbt] (
   val defaultConfiguration: Option[Configuration],
   val ivyScala: Option[IvyScala],
   val validate: Boolean,
-  val conflictManager: ConflictManager
+  val conflictManager: ConflictManager,
+  val defaultConfMapping: Option[String]
 ) extends ModuleSettings {
   def withConfigurations(configurations: Seq[Configuration]) = copy(configurations = configurations)
   def noScala = copy(ivyScala = None)
@@ -144,14 +145,15 @@ final class InlineConfiguration private[sbt] (
     defaultConfiguration: Option[Configuration] = this.defaultConfiguration,
     ivyScala: Option[IvyScala] = this.ivyScala,
     validate: Boolean = this.validate,
-    conflictManager: ConflictManager = this.conflictManager
+    conflictManager: ConflictManager = this.conflictManager,
+    defaultConfMapping: Option[String] = this.defaultConfMapping
   ): InlineConfiguration =
     InlineConfiguration(module, moduleInfo, dependencies, overrides, excludes, ivyXML,
-      configurations, defaultConfiguration, ivyScala, validate, conflictManager)
+      configurations, defaultConfiguration, ivyScala, validate, conflictManager, defaultConfMapping)
 
   override def toString: String =
     s"InlineConfiguration($module, $moduleInfo, $dependencies, $overrides, $excludes, " +
-      s"$ivyXML, $configurations, $defaultConfiguration, $ivyScala, $validate, $conflictManager)"
+      s"$ivyXML, $configurations, $defaultConfiguration, $ivyScala, $validate, $conflictManager, $defaultConfMapping)"
 
   override def equals(o: Any): Boolean = o match {
     case o: InlineConfiguration =>
@@ -165,7 +167,8 @@ final class InlineConfiguration private[sbt] (
         this.defaultConfiguration == o.defaultConfiguration &&
         this.ivyScala == o.ivyScala &&
         this.validate == o.validate &&
-        this.conflictManager == o.conflictManager
+        this.conflictManager == o.conflictManager &&
+        this.defaultConfMapping == o.defaultConfMapping
     case _ => false
   }
 
@@ -197,10 +200,11 @@ object InlineConfiguration {
     defaultConfiguration: Option[Configuration] = None,
     ivyScala: Option[IvyScala] = None,
     validate: Boolean = false,
-    conflictManager: ConflictManager = ConflictManager.default
+    conflictManager: ConflictManager = ConflictManager.default,
+    defaultConfMapping: Option[String] = None
   ): InlineConfiguration =
     new InlineConfiguration(module, moduleInfo, dependencies, overrides, excludes, ivyXML,
-      configurations, defaultConfiguration, ivyScala, validate, conflictManager)
+      configurations, defaultConfiguration, ivyScala, validate, conflictManager, defaultConfMapping)
 
   def configurations(explicitConfigurations: Iterable[Configuration], defaultConfiguration: Option[Configuration]) =
     if (explicitConfigurations.isEmpty) {


### PR DESCRIPTION
The defaultConfMapping in ivy is currently hard-coded to `*->default(compile)`. This works well for most purposes, but I have a use case where it falls short.  

Say I want to have a flag that, when enabled, requires users to list all their `compile` dependencies explicitly. Everything they depend on + their transitive dependencies will end up in the `runtime` scope, but `compile` will only contain packages _explicitly listed as dependencies_.
This is what some call the _include-what-you-use_ principle, and it's useful to prevent you from using code from a transitive dependency B, in case your dependency A that depended on B stops depending on B later on, and subsequently causes your code to not compile anymore, even though you haven't made any changes to it.

Let's say I build all my packages to export an `only-me` configuration, that contains only the artifacts published, but no dependencies. Now, when I activate this flag, it would be a pain to have to change all the dependencies in that project from 
- no dependency mapping at all, or
- `compile`

to `compile->only-me(default)`.

But if we can modify the `defaultConfMapping`, we'd just set that to `*->only-me(default)`, and this would do what you want without having to parse the configuration mapping of each dependency and mangle it programmatically.
