### PR TITLE
Fix small typo ("Sorrting" should be "Sorting")

### DIFF
--- a/librarymanagement/src/main/scala/sbt/internal/librarymanagement/ivyint/SbtChainResolver.scala
+++ b/librarymanagement/src/main/scala/sbt/internal/librarymanagement/ivyint/SbtChainResolver.scala
@@ -165,7 +165,7 @@ private[sbt] case class SbtChainResolver(
         def sorted =
           if (useLatest) (foundRevisions.sortBy {
             case (rmr, resolver) =>
-              Message.warn(s"Sorrting results from $rmr, using ${rmr.getPublicationDate} and ${rmr.getDescriptor.getPublicationDate}")
+              Message.warn(s"Sorting results from $rmr, using ${rmr.getPublicationDate} and ${rmr.getDescriptor.getPublicationDate}")
               // Just issue warning about issues with publication date, and fake one on it for now.
               Option(rmr.getPublicationDate) orElse Option(rmr.getDescriptor.getPublicationDate) match {
                 case None =>


### PR DESCRIPTION
This PR fixes a small typo in `SbtChainResolver.scala` ("**Sorrting** results from $rmr, using ${rmr.getPublicationDate} and ${rmr.getDescriptor.getPublicationDate").

This typo is also on [sbt/sbt-zero-thirteen](https://github.com/sbt/sbt-zero-thirteen/blob/d9f10853fb5cece1c0e598d2dd08756a95f7bd43/ivy/src/main/scala/sbt/ivyint/SbtChainResolver.scala). Should I send another PR there?
