### PR TITLE
Make CrossVersion & ModuleId more commonly equal

### DIFF
--- a/librarymanagement/src/main/scala/sbt/librarymanagement/CrossVersion.scala
+++ b/librarymanagement/src/main/scala/sbt/librarymanagement/CrossVersion.scala
@@ -26,6 +26,11 @@ object CrossVersion {
    */
   final class Binary(val remapVersion: String => String) extends CrossVersion {
     override def toString = "Binary"
+    override def hashCode = remapVersion.##
+    override def equals(that: Any) = that match {
+      case that: Binary => this.remapVersion == that.remapVersion
+      case _            => false
+    }
   }
 
   /**
@@ -35,6 +40,11 @@ object CrossVersion {
    */
   final class Full(val remapVersion: String => String) extends CrossVersion {
     override def toString = "Full"
+    override def hashCode = remapVersion.##
+    override def equals(that: Any) = that match {
+      case that: Full => this.remapVersion == that.remapVersion
+      case _          => false
+    }
   }
 
   private val disabledTag = implicitly[FastTypeTag[Disabled.type]]
@@ -75,7 +85,7 @@ object CrossVersion {
   }
 
   /** Cross-versions a module with the full version (typically the full Scala version). */
-  def full: CrossVersion = new Full(idFun)
+  def full: CrossVersion = new Full(idStringFun)
 
   /**
    * Cross-versions a module with the result of applying `remapVersion` to the full version
@@ -84,7 +94,7 @@ object CrossVersion {
   def fullMapped(remapVersion: String => String): CrossVersion = new Full(remapVersion)
 
   /** Cross-versions a module with the binary version (typically the binary Scala version).  */
-  def binary: CrossVersion = new Binary(idFun)
+  def binary: CrossVersion = new Binary(idStringFun)
 
   /**
    * Cross-versions a module with the result of applying `remapVersion` to the binary version
@@ -93,6 +103,7 @@ object CrossVersion {
   def binaryMapped(remapVersion: String => String): CrossVersion = new Binary(remapVersion)
 
   private[this] def idFun[T]: T => T = x => x
+  private[this] val idStringFun = idFun[String]
 
   private[sbt] def append(s: String): Option[String => String] = Some(x => crossName(x, s))
 

--- a/librarymanagement/src/test/scala/CrossVersionTest.scala
+++ b/librarymanagement/src/test/scala/CrossVersionTest.scala
@@ -115,4 +115,13 @@ class CrossVersionTest extends UnitSpec {
   it should "return binary Scala version for 2.10.1 as 2.10" in {
     CrossVersion.binaryScalaVersion("2.10.1") shouldBe "2.10"
   }
+  it should "return disabled cross version as equal to a copy" in {
+    CrossVersion.Disabled shouldBe CrossVersion.Disabled
+  }
+  it should "return full cross version as equal to a copy" in {
+    CrossVersion.full shouldBe CrossVersion.full
+  }
+  it should "return binary cross version as equal to a copy" in {
+    CrossVersion.binary shouldBe CrossVersion.binary
+  }
 }

--- a/librarymanagement/src/test/scala/ModuleIdTest.scala
+++ b/librarymanagement/src/test/scala/ModuleIdTest.scala
@@ -1,0 +1,17 @@
+package sbt.librarymanagement
+
+import sbt.internal.util.UnitSpec
+
+class ModuleIdTest extends UnitSpec {
+  "Module Id" should "return cross-disabled module id as equal to a copy" in {
+    ModuleID("com.acme", "foo", "1") shouldBe ModuleID("com.acme", "foo", "1")
+  }
+  it should "return cross-full module id as equal to a copy" in {
+    (ModuleID("com.acme", "foo", "1") cross CrossVersion.full) shouldBe
+      (ModuleID("com.acme", "foo", "1") cross CrossVersion.full)
+  }
+  it should "return cross-binary module id as equal to a copy" in {
+    (ModuleID("com.acme", "foo", "1") cross CrossVersion.binary) shouldBe
+      (ModuleID("com.acme", "foo", "1") cross CrossVersion.binary)
+  }
+}


### PR DESCRIPTION
Two instance of functions defined in the same way don't equal themselves, but
the same instance of a function does. So by using a val idStringFun for full and
binary, and making Binary and Full case classes there are much better chances
that ModuleId's defined in the same way will be equal.
