### PR TITLE
Fix ConfigurationReport.toString

### DIFF
--- a/librarymanagement/src/main/datatype/librarymanagement.json
+++ b/librarymanagement/src/main/datatype/librarymanagement.json
@@ -99,6 +99,11 @@
           "type": "sbt.librarymanagement.OrganizationArtifactReport*",
           "doc": [ "a sequence containing one report for each org/name, which may or may not be part of the final resolution." ]
         }
+      ],
+      "toString": [
+        "s\"\\t$configuration:\\n\" +",
+        "(if (details.isEmpty) modules.mkString + details.flatMap(_.modules).filter(_.evicted).map(\"\\t\\t(EVICTED) \" + _ + \"\\n\").mkString",
+        "else details.mkString)"
       ]
     },
     {

--- a/librarymanagement/src/main/scala/sbt/librarymanagement/UpdateReportExtra.scala
+++ b/librarymanagement/src/main/scala/sbt/librarymanagement/UpdateReportExtra.scala
@@ -15,10 +15,6 @@ abstract class ConfigurationReportExtra {
   def evicted: Seq[ModuleID] =
     details flatMap (_.modules) filter (_.evicted) map (_.module)
 
-  override def toString = s"\t$configuration:\n" +
-    (if (details.isEmpty) modules.mkString + details.flatMap(_.modules).filter(_.evicted).map("\t\t(EVICTED) " + _ + "\n").mkString
-    else details.mkString)
-
   /**
    * All resolved modules for this configuration.
    * For a given organization and module name, there is only one revision/`ModuleID` in this sequence.


### PR DESCRIPTION
Move the toString implementation from ConfigurationReportExtra to inside the ConfigurationReport JSON schema definition, that way the synthetic toString generated by contraband doesn't override the carefully defined one.