### PR TITLE
Allow for some customization in CrossVersion results

### DIFF
--- a/librarymanagement/src/main/contraband/librarymanagement.json
+++ b/librarymanagement/src/main/contraband/librarymanagement.json
@@ -138,12 +138,16 @@
           "namespace": "sbt.librarymanagement",
           "target": "Scala",
           "doc": [
-            "Cross-versions a module using the result of appending `suffix` to the binary version.",
-            "For example, if `suffix = \"_foo\"` and the binary version is \"2.10\",",
-            "the module is cross-versioned with \"2.10_foo\"."
+            "Cross-versions a module using the result of",
+            "prepending `prefix` and appending `suffix` to the binary version.",
+            "For example, if `prefix = \"foo_\"` and `suffix = \"_bar\"` and the binary version is \"2.10\",",
+            "the module is cross-versioned with \"foo_2.10_bar\"."
           ],
           "type": "record",
-          "fields": [ { "name": "suffix", "type": "String", "default": "\"\"", "since": "0.0.1" } ]
+          "fields": [
+            { "name": "prefix", "type": "String", "default": "\"\"", "since": "0.0.1" },
+            { "name": "suffix", "type": "String", "default": "\"\"", "since": "0.0.1" }
+          ]
         },
         {
           "name": "Patch",
@@ -161,11 +165,15 @@
           "target": "Scala",
           "type": "record",
           "doc": [
-            "Cross-versions a module with the result of appending `suffix` to the full version.",
-            "For example, if `suffix = \"_foo\"` and the full version is \"2.12.1\",",
-            "the module is cross-versioned with \"2.12.1_foo\"."
+            "Cross-versions a module with the result of",
+            "prepending `prefix` and appending `suffix` to the full version.",
+            "For example, if `prefix = \"foo_\"` and `suffix = \"_bar\"` and the full version is \"2.12.1\",",
+            "the module is cross-versioned with \"foo_2.12.1_bar\"."
           ],
-          "fields": [ { "name": "suffix", "type": "String", "default": "\"\"", "since": "0.0.1" } ]
+          "fields": [
+            { "name": "prefix", "type": "String", "default": "\"\"", "since": "0.0.1" },
+            { "name": "suffix", "type": "String", "default": "\"\"", "since": "0.0.1" }
+          ]
         }
       ],
       "parentsCompanion": "sbt.librarymanagement.CrossVersionFunctions"

--- a/librarymanagement/src/main/contraband/librarymanagement.json
+++ b/librarymanagement/src/main/contraband/librarymanagement.json
@@ -138,11 +138,12 @@
           "namespace": "sbt.librarymanagement",
           "target": "Scala",
           "doc": [
-            "Cross-versions a module using the result of applying `remapVersion` to the binary version.",
-            "For example, if `remapVersion = v => \"2.10\"` and the binary version is \"2.9.2\" or \"2.10\",",
-            "the module is cross-versioned with \"2.10\"."
+            "Cross-versions a module using the result of appending `suffix` to the binary version.",
+            "For example, if `suffix = \"_foo\"` and the binary version is \"2.10\",",
+            "the module is cross-versioned with \"2.10_foo\"."
           ],
-          "type": "record"
+          "type": "record",
+          "fields": [ { "name": "suffix", "type": "String", "default": "\"\"", "since": "0.0.1" } ]
         },
         {
           "name": "Patch",
@@ -150,7 +151,7 @@
           "target": "Scala",
           "doc": [
             "Cross-versions a module by stripping off -bin-suffix.",
-            "This is intented for patch-version compatible alternative replacements."
+            "This is intended for patch-version compatible alternative replacements."
           ],
           "type": "record"
         },
@@ -160,10 +161,11 @@
           "target": "Scala",
           "type": "record",
           "doc": [
-            "Cross-versions a module with the result of applying `remapVersion` to the full version.",
-            "For example, if `remapVersion = v => \"2.10\"` and the full version is \"2.9.2\" or \"2.10.3\",",
-            "the module is cross-versioned with \"2.10\"."
-          ]
+            "Cross-versions a module with the result of appending `suffix` to the full version.",
+            "For example, if `suffix = \"_foo\"` and the full version is \"2.12.1\",",
+            "the module is cross-versioned with \"2.12.1_foo\"."
+          ],
+          "fields": [ { "name": "suffix", "type": "String", "default": "\"\"", "since": "0.0.1" } ]
         }
       ],
       "parentsCompanion": "sbt.librarymanagement.CrossVersionFunctions"

--- a/librarymanagement/src/main/scala/sbt/internal/librarymanagement/IvyActions.scala
+++ b/librarymanagement/src/main/scala/sbt/internal/librarymanagement/IvyActions.scala
@@ -21,7 +21,6 @@ import sbt.util.{ Logger, ShowLines }
 import sbt.internal.util.{ SourcePosition, LinePosition, RangePosition, LineRange }
 import sbt.librarymanagement._
 import sbt.internal.librarymanagement.syntax._
-import sbt.internal.librarymanagement._
 
 final class DeliverConfiguration(val deliverIvyPattern: String, val status: String, val configurations: Option[Vector[Configuration]], val logging: UpdateLogging)
 final class PublishConfiguration(val ivyFile: Option[File], val resolverName: String, val artifacts: Map[Artifact, File], val checksums: Vector[String], val logging: UpdateLogging,

--- a/librarymanagement/src/main/scala/sbt/internal/librarymanagement/ivyint/CachedResolutionResolveEngine.scala
+++ b/librarymanagement/src/main/scala/sbt/internal/librarymanagement/ivyint/CachedResolutionResolveEngine.scala
@@ -123,13 +123,13 @@ private[sbt] class CachedResolutionResolveCache(fileToStore: File => CacheStore)
     }
   def extractOverrides(md0: ModuleDescriptor): Vector[IvyOverride] =
     {
-      import scala.collection.JavaConversions._
-      (md0.getAllDependencyDescriptorMediators.getAllRules).toSeq.toVector sortBy {
+      import scala.collection.JavaConverters._
+      md0.getAllDependencyDescriptorMediators.getAllRules.asScala.toSeq.toVector sortBy {
         case (k, v) =>
           k.toString
       } collect {
         case (k: MapMatcher, v: OverrideDependencyDescriptorMediator) =>
-          val attr: Map[Any, Any] = k.getAttributes.toMap
+          val attr: Map[Any, Any] = k.getAttributes.asScala.toMap
           val module = IvyModuleId.newInstance(attr(IvyPatternHelper.ORGANISATION_KEY).toString, attr(IvyPatternHelper.MODULE_KEY).toString)
           val pm = k.getPatternMatcher
           IvyOverride(module, pm, v)

--- a/librarymanagement/src/main/scala/sbt/librarymanagement/Credentials.scala
+++ b/librarymanagement/src/main/scala/sbt/librarymanagement/Credentials.scala
@@ -58,12 +58,12 @@ object Credentials {
   private[this] val UserKeys = List("user", "user.name", "username")
   private[this] val PasswordKeys = List("password", "pwd", "pass", "passwd")
 
-  import collection.JavaConversions._
+  import collection.JavaConverters._
   private[this] def read(from: File): Map[String, String] =
     {
       val properties = new java.util.Properties
       IO.load(properties, from)
-      properties.map { case (k, v) => (k.toString, v.toString.trim) }.toMap
+      properties.asScala.map { case (k, v) => (k.toString, v.toString.trim) }.toMap
     }
 }
 

--- a/librarymanagement/src/main/scala/sbt/librarymanagement/CrossVersionExtra.scala
+++ b/librarymanagement/src/main/scala/sbt/librarymanagement/CrossVersionExtra.scala
@@ -15,8 +15,20 @@ abstract class CrossVersionFunctions {
   /** Cross-versions a module with the full version (typically the full Scala version). */
   def full: CrossVersion = Full()
 
+  /**
+   * Cross-versions a module with the result of appending `suffix` to the full version.
+   * (typically the full Scala version).  See also [[sbt.librarymanagement.Full]]
+   */
+  def fullSuffixed(suffix: String): CrossVersion = Full(suffix)
+
   /** Cross-versions a module with the binary version (typically the binary Scala version).  */
   def binary: CrossVersion = Binary()
+
+  /**
+   * Cross-versions a module with the result of appending `suffix` to the binary version
+   * (typically the binary Scala version).  See also [[sbt.librarymanagement.Binary]].
+   */
+  def binarySuffixed(suffix: String): CrossVersion = Binary(suffix)
 
   /**
    * Cross-versions a module with the full Scala version excluding any `-bin` suffix.
@@ -41,9 +53,9 @@ abstract class CrossVersionFunctions {
   def apply(cross: CrossVersion, fullVersion: String, binaryVersion: String): Option[String => String] =
     cross match {
       case _: Disabled => None
-      case _: Binary   => append(binaryVersion)
+      case b: Binary   => append(binaryVersion + b.suffix)
       case _: Patch    => append(patchFun(fullVersion))
-      case _: Full     => append(fullVersion)
+      case f: Full     => append(fullVersion + f.suffix)
     }
 
   /** Constructs the cross-version function defined by `module` and `is`, if one is configured. */

--- a/librarymanagement/src/main/scala/sbt/librarymanagement/CrossVersionExtra.scala
+++ b/librarymanagement/src/main/scala/sbt/librarymanagement/CrossVersionExtra.scala
@@ -16,19 +16,19 @@ abstract class CrossVersionFunctions {
   def full: CrossVersion = Full()
 
   /**
-   * Cross-versions a module with the result of appending `suffix` to the full version.
+   * Cross-versions a module with the result of prepending `prefix` and appending `suffix` to the full version.
    * (typically the full Scala version).  See also [[sbt.librarymanagement.Full]]
    */
-  def fullSuffixed(suffix: String): CrossVersion = Full(suffix)
+  def fullWith(prefix: String, suffix: String): CrossVersion = Full(prefix, suffix)
 
   /** Cross-versions a module with the binary version (typically the binary Scala version).  */
   def binary: CrossVersion = Binary()
 
   /**
-   * Cross-versions a module with the result of appending `suffix` to the binary version
+   * Cross-versions a module with the result of prepending `prefix` and appending `suffix` to the binary version
    * (typically the binary Scala version).  See also [[sbt.librarymanagement.Binary]].
    */
-  def binarySuffixed(suffix: String): CrossVersion = Binary(suffix)
+  def binaryWith(prefix: String, suffix: String): CrossVersion = Binary(prefix, suffix)
 
   /**
    * Cross-versions a module with the full Scala version excluding any `-bin` suffix.
@@ -53,9 +53,9 @@ abstract class CrossVersionFunctions {
   def apply(cross: CrossVersion, fullVersion: String, binaryVersion: String): Option[String => String] =
     cross match {
       case _: Disabled => None
-      case b: Binary   => append(binaryVersion + b.suffix)
+      case b: Binary   => append(b.prefix + binaryVersion + b.suffix)
       case _: Patch    => append(patchFun(fullVersion))
-      case f: Full     => append(fullVersion + f.suffix)
+      case f: Full     => append(f.prefix + fullVersion + f.suffix)
     }
 
   /** Constructs the cross-version function defined by `module` and `is`, if one is configured. */

--- a/librarymanagement/src/main/scala/sbt/librarymanagement/DefaultLibraryManagement.scala
+++ b/librarymanagement/src/main/scala/sbt/librarymanagement/DefaultLibraryManagement.scala
@@ -2,7 +2,6 @@ package sbt
 package librarymanagement
 
 import java.io.File
-import scala.util.Try
 import sbt.internal.librarymanagement._
 import sbt.util.Logger
 import sbt.io.Hash
@@ -61,7 +60,7 @@ class DefaultLibraryManagement(ivyConfiguration: IvyConfiguration, log: Logger) 
     log.debug(s"Attempting to fetch ${dependenciesNames(module)}. This operation may fail.")
     IvyActions.updateEither(module, updateConfiguration, UnresolvedWarningConfiguration(), LogicalClock.unknown, None, log) match {
       case Left(unresolvedWarning) =>
-        log.debug("Couldn't retrieve module ${dependenciesNames(module)}.")
+        log.debug(s"Couldn't retrieve module ${dependenciesNames(module)}.")
         None
 
       case Right(updateReport) =>

--- a/librarymanagement/src/test/scala/DMSerializationSpec.scala
+++ b/librarymanagement/src/test/scala/DMSerializationSpec.scala
@@ -6,6 +6,7 @@ import java.io.File
 import sbt.internal._, librarymanagement._, util.UnitSpec
 import scala.json.ast.unsafe._
 import sjsonnew._, support.scalajson.unsafe._
+import org.scalatest.Assertion
 
 import LibraryManagementCodec._
 
@@ -61,11 +62,13 @@ class DMSerializationSpec extends UnitSpec {
   lazy val moduleReportExample =
     ModuleReport(ModuleID("org", "name", "1.0"), Vector.empty, Vector.empty)
 
-  def roundtrip[A: JsonReader: JsonWriter](a: A): Unit =
+  def roundtrip[A: JsonReader: JsonWriter](a: A): Assertion =
     roundtripBuilder(a) { _ shouldBe _ }
-  def roundtripStr[A: JsonReader: JsonWriter](a: A): Unit =
+
+  def roundtripStr[A: JsonReader: JsonWriter](a: A): Assertion =
     roundtripBuilder(a) { _.toString shouldBe _.toString }
-  def roundtripBuilder[A: JsonReader: JsonWriter](a: A)(f: (A, A) => Unit): Unit =
+
+  def roundtripBuilder[A: JsonReader: JsonWriter](a: A)(f: (A, A) => Assertion): Assertion =
     {
       val json = isoString to (Converter toJsonUnsafe a)
       println(json)


### PR DESCRIPTION
The old way to customize CrossVersion results was a `String => String`
function called 'remapVersion', removed in
301ec787f2f17367064cda5eef3a9009ba66e21f.

That was removed because it's not possible to serialise Function1s, and we
want to serialise CrossVersion (and therefore ModuleID, etc) to be able to
transfer them in sbt server.

This commit reintroduces a less-powerful way to vary the results of apply
CrossVersion, but just providing the opportunity to define a suffix. From
looking at the users of CrossVersion (Scala.js' sbt-scalajs-plugin & Scala
Native's sbt-crossproject) this looks to be sufficient.