### PR TITLE
Bump to util 1.0.0-M23

### DIFF
--- a/librarymanagement/src/main/scala/sbt/internal/librarymanagement/Ivy.scala
+++ b/librarymanagement/src/main/scala/sbt/internal/librarymanagement/Ivy.scala
@@ -30,9 +30,8 @@ import sbt.util.Logger
 import sbt.librarymanagement._
 import Resolver.PluginPattern
 import ivyint.{ CachedResolutionResolveEngine, CachedResolutionResolveCache, SbtDefaultDependencyDescriptor }
-import sbt.internal.util.CacheStore
 
-final class IvySbt(val configuration: IvyConfiguration, fileToStore: File => CacheStore) { self =>
+final class IvySbt(val configuration: IvyConfiguration) { self =>
   import configuration.baseDirectory
 
   /*
@@ -93,8 +92,7 @@ final class IvySbt(val configuration: IvyConfiguration, fileToStore: File => Cac
           setEventManager(new EventManager())
           if (configuration.updateOptions.cachedResolution) {
             setResolveEngine(new ResolveEngine(getSettings, getEventManager, getSortEngine) with CachedResolutionResolveEngine {
-              override private[sbt] val fileToStore: File => CacheStore = self.fileToStore
-              val cachedResolutionResolveCache = IvySbt.cachedResolutionResolveCache(fileToStore)
+              val cachedResolutionResolveCache = IvySbt.cachedResolutionResolveCache
               val projectResolver = prOpt
               def makeInstance = mkIvy
             })
@@ -141,7 +139,7 @@ final class IvySbt(val configuration: IvyConfiguration, fileToStore: File => Cac
     withIvy(log) { i =>
       val prOpt = Option(i.getSettings.getResolver(ProjectResolver.InterProject)) map { case pr: ProjectResolver => pr }
       if (configuration.updateOptions.cachedResolution) {
-        IvySbt.cachedResolutionResolveCache(fileToStore).clean(md, prOpt)
+        IvySbt.cachedResolutionResolveCache.clean(md, prOpt)
       }
     }
 
@@ -251,7 +249,7 @@ private[sbt] object IvySbt {
   val DefaultIvyFilename = "ivy.xml"
   val DefaultMavenFilename = "pom.xml"
   val DefaultChecksums = Vector("sha1", "md5")
-  private[sbt] def cachedResolutionResolveCache(fileToStore: File => CacheStore): CachedResolutionResolveCache = new CachedResolutionResolveCache(fileToStore)
+  private[sbt] def cachedResolutionResolveCache: CachedResolutionResolveCache = new CachedResolutionResolveCache
 
   def defaultIvyFile(project: File) = new File(project, DefaultIvyFilename)
   def defaultIvyConfiguration(project: File) = new File(project, DefaultIvyConfigFilename)

--- a/librarymanagement/src/main/scala/sbt/internal/librarymanagement/JsonUtil.scala
+++ b/librarymanagement/src/main/scala/sbt/internal/librarymanagement/JsonUtil.scala
@@ -3,22 +3,18 @@ package sbt.internal.librarymanagement
 import java.io.File
 import org.apache.ivy.core
 import core.module.descriptor.ModuleDescriptor
-import sbt.util.Logger
-import sbt.internal.util.CacheStore
+import sbt.util.{ CacheStore, Logger }
 import sbt.librarymanagement._
 import sbt.librarymanagement.LibraryManagementCodec._
-import JsonUtil._
 
 private[sbt] object JsonUtil {
   def sbtOrgTemp = "org.scala-sbt.temp"
   def fakeCallerOrganization = "org.scala-sbt.temp-callers"
-}
 
-private[sbt] class JsonUtil(fileToStore: File => CacheStore) {
   def parseUpdateReport(md: ModuleDescriptor, path: File, cachedDescriptor: File, log: Logger): UpdateReport =
     {
       try {
-        val lite = fileToStore(path).read[UpdateReportLite]
+        val lite = CacheStore(path).read[UpdateReportLite]
         fromLite(lite, cachedDescriptor)
       } catch {
         case e: Throwable =>
@@ -29,7 +25,7 @@ private[sbt] class JsonUtil(fileToStore: File => CacheStore) {
   def writeUpdateReport(ur: UpdateReport, graphPath: File): Unit =
     {
       sbt.io.IO.createDirectory(graphPath.getParentFile)
-      fileToStore(graphPath).write(toLite(ur))
+      CacheStore(graphPath).write(toLite(ur))
     }
   def toLite(ur: UpdateReport): UpdateReportLite =
     UpdateReportLite(ur.configurations map { cr =>

--- a/librarymanagement/src/main/scala/sbt/librarymanagement/DefaultLibraryManagement.scala
+++ b/librarymanagement/src/main/scala/sbt/librarymanagement/DefaultLibraryManagement.scala
@@ -7,7 +7,7 @@ import sbt.util.Logger
 import sbt.io.Hash
 
 class DefaultLibraryManagement(ivyConfiguration: IvyConfiguration, log: Logger) extends LibraryManagement {
-  private[sbt] val ivySbt: IvySbt = new IvySbt(ivyConfiguration, DefaultFileToStore)
+  private[sbt] val ivySbt: IvySbt = new IvySbt(ivyConfiguration)
   private val sbtOrgTemp = JsonUtil.sbtOrgTemp
   private val modulePrefixTemp = "temp-module-"
 

--- a/librarymanagement/src/test/scala/BaseIvySpecification.scala
+++ b/librarymanagement/src/test/scala/BaseIvySpecification.scala
@@ -8,13 +8,6 @@ import sbt.internal.util.ConsoleLogger
 import sbt.librarymanagement._
 import Configurations._
 
-import sbt.internal.util.FileBasedStore
-
-import sjsonnew.IsoString
-import sjsonnew.support.scalajson.unsafe.{ CompactPrinter, Converter }
-
-import scala.json.ast.unsafe.JValue
-
 trait BaseIvySpecification extends UnitSpec {
   def currentBase: File = new File(".")
   def currentTarget: File = currentBase / "target" / "ivyhome"
@@ -22,8 +15,6 @@ trait BaseIvySpecification extends UnitSpec {
   def currentDependency: File = currentBase / "target" / "dependency"
   def defaultModuleId: ModuleID = ModuleID("com.example", "foo", "0.1.0").withConfigurations(Some("compile"))
 
-  implicit val isoString: IsoString[JValue] = IsoString.iso(CompactPrinter.apply, FixedParser.parseUnsafe)
-  val fileToStore = (f: File) => new FileBasedStore(f, Converter)
   lazy val log = ConsoleLogger()
 
   def configurations = Vector(Compile, Test, Runtime)
@@ -47,7 +38,7 @@ trait BaseIvySpecification extends UnitSpec {
       moduleInfo = ModuleInfo("foo"),
       dependencies = deps
     ).withConfigurations(configurations)
-    val ivySbt = new IvySbt(mkIvyConfiguration(uo), fileToStore)
+    val ivySbt = new IvySbt(mkIvyConfiguration(uo))
     new ivySbt.Module(moduleSetting)
   }
 

--- a/librarymanagement/src/test/scala/CustomPomParserTest.scala
+++ b/librarymanagement/src/test/scala/CustomPomParserTest.scala
@@ -16,7 +16,7 @@ class CustomPomParserTest extends UnitSpec {
       val local = MavenRepository("Test Repo", repoUrl.toExternalForm)
       val paths = IvyPaths(new File("."), Some(cacheDir))
       val conf = new InlineIvyConfiguration(paths, Vector(local), Vector.empty, Vector.empty, false, None, Vector("sha1", "md5"), None, UpdateOptions(), log)
-      val ivySbt = new IvySbt(conf, DefaultFileToStore)
+      val ivySbt = new IvySbt(conf)
       val resolveOpts = new ResolveOptions().setConfs(Array("default"))
       val mrid = ModuleRevisionId.newInstance("com.test", "test-artifact", "1.0.0-SNAPSHOT")
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,8 +5,8 @@ object Dependencies {
   val scala211 = "2.11.8"
   val scala212 = "2.12.1"
 
-  private val ioVersion = "1.0.0-M10"
-  private val utilVersion = "1.0.0-M22"
+  private val ioVersion = "1.0.0-M11"
+  private val utilVersion = "1.0.0-M23"
 
   private val sbtIO = "org.scala-sbt" %% "io" % ioVersion
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=0.13.15


### PR DESCRIPTION
I'm now going to use `CacheStore.apply` in `JsonUtil` (used by cached resolution). This gets rid of `fileToStore` parameter from a bunch of classes and simplifies the setup around librarymanagement.