### PR TITLE
Add a frozen mode to update configuration

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,6 +19,7 @@ def commonSettings: Seq[Setting[_]] = Seq(
   mimaPreviousArtifacts := Set(), // Some(organization.value %% moduleName.value % "1.0.0"),
   publishArtifact in Compile := true,
   publishArtifact in Test := false,
+  parallelExecution in Test := false,
   commands += Command.command("scalafmtCheck") { state =>
     sys.process.Process("git diff --name-only --exit-code").! match {
       case 0 => // ok

--- a/librarymanagement/src/main/contraband/librarymanagement.json
+++ b/librarymanagement/src/main/contraband/librarymanagement.json
@@ -729,7 +729,6 @@
             { "name": "resolvers",            "type": "sbt.librarymanagement.Resolver*"            },
             { "name": "otherResolvers",       "type": "sbt.librarymanagement.Resolver*"            },
             { "name": "moduleConfigurations", "type": "sbt.librarymanagement.ModuleConfiguration*" },
-            { "name": "localOnly",            "type": "boolean"                                    },
             { "name": "checksums",            "type": "String*"                                    },
             { "name": "resolutionCacheDir",   "type": "java.io.File?"                              }
           ],
@@ -739,7 +738,6 @@
             "  resolvers:            Vector[sbt.librarymanagement.Resolver],",
             "  otherResolvers:       Vector[sbt.librarymanagement.Resolver],",
             "  moduleConfigurations: Vector[sbt.librarymanagement.ModuleConfiguration],",
-            "  localOnly:            Boolean,",
             "  lock:                 Option[xsbti.GlobalLock],",
             "  checksums:            Vector[String],",
             "  resolutionCacheDir:   Option[java.io.File],",
@@ -747,7 +745,7 @@
             "  log:                  xsbti.Logger",
             ") =",
             "  this(lock, paths.baseDirectory, log, updateOptions, paths, resolvers, otherResolvers,",
-            "    moduleConfigurations, localOnly, checksums, resolutionCacheDir)"
+            "    moduleConfigurations, checksums, resolutionCacheDir)"
           ]
         },
         {

--- a/librarymanagement/src/main/contraband/librarymanagement.json
+++ b/librarymanagement/src/main/contraband/librarymanagement.json
@@ -634,7 +634,8 @@
         { "name": "retrieve",       "type": "sbt.internal.librarymanagement.RetrieveConfiguration?" },
         { "name": "missingOk",      "type": "boolean"                                               },
         { "name": "logging",        "type": "sbt.librarymanagement.UpdateLogging"                   },
-        { "name": "artifactFilter", "type": "sbt.librarymanagement.ArtifactTypeFilter"              }
+        { "name": "artifactFilter", "type": "sbt.librarymanagement.ArtifactTypeFilter"              },
+        { "name": "offline",        "type": "boolean"                                               }
       ]
     },
     {

--- a/librarymanagement/src/main/contraband/librarymanagement.json
+++ b/librarymanagement/src/main/contraband/librarymanagement.json
@@ -635,7 +635,8 @@
         { "name": "missingOk",      "type": "boolean"                                               },
         { "name": "logging",        "type": "sbt.librarymanagement.UpdateLogging"                   },
         { "name": "artifactFilter", "type": "sbt.librarymanagement.ArtifactTypeFilter"              },
-        { "name": "offline",        "type": "boolean"                                               }
+        { "name": "offline",        "type": "boolean"                                               },
+        { "name": "frozen",         "type": "boolean"                                               }
       ]
     },
     {

--- a/librarymanagement/src/main/scala/sbt/internal/librarymanagement/ConvertResolver.scala
+++ b/librarymanagement/src/main/scala/sbt/internal/librarymanagement/ConvertResolver.scala
@@ -202,7 +202,7 @@ private[sbt] object ConvertResolver {
           resolver
         }
         case repo: ChainedResolver =>
-          IvySbt.resolverChain(repo.name, repo.resolvers, false, settings, log)
+          IvySbt.resolverChain(repo.name, repo.resolvers, settings, log)
         case repo: RawRepository => repo.resolver
       }
   }

--- a/librarymanagement/src/main/scala/sbt/internal/librarymanagement/IvyActions.scala
+++ b/librarymanagement/src/main/scala/sbt/internal/librarymanagement/IvyActions.scala
@@ -467,6 +467,7 @@ object IvyActions {
     val resolveId = ResolveOptions.getDefaultResolveId(moduleDescriptor)
     resolveOptions.setResolveId(resolveId)
     resolveOptions.setArtifactFilter(updateConfiguration.artifactFilter)
+    resolveOptions.setUseCacheOnly(updateConfiguration.offline)
     resolveOptions.setLog(ivyLogLevel(logging))
     ResolutionCache.cleanModule(
       moduleDescriptor.getModuleRevisionId,
@@ -519,6 +520,7 @@ object IvyActions {
     val resolveId = ResolveOptions.getDefaultResolveId(descriptor)
     resolveOptions.setResolveId(resolveId)
     resolveOptions.setArtifactFilter(updateConfiguration.artifactFilter)
+    resolveOptions.setUseCacheOnly(updateConfiguration.offline)
     resolveOptions.setLog(ivyLogLevel(updateConfiguration.logging))
     val acceptError = updateConfiguration.missingOk
     resolver.customResolve(descriptor, acceptError, logicalClock, resolveOptions, cache, log)

--- a/librarymanagement/src/main/scala/sbt/internal/librarymanagement/IvyActions.scala
+++ b/librarymanagement/src/main/scala/sbt/internal/librarymanagement/IvyActions.scala
@@ -469,6 +469,10 @@ object IvyActions {
     resolveOptions.setArtifactFilter(updateConfiguration.artifactFilter)
     resolveOptions.setUseCacheOnly(updateConfiguration.offline)
     resolveOptions.setLog(ivyLogLevel(logging))
+    if (updateConfiguration.frozen) {
+      resolveOptions.setTransitive(false)
+      resolveOptions.setCheckIfChanged(false)
+    }
     ResolutionCache.cleanModule(
       moduleDescriptor.getModuleRevisionId,
       resolveId,
@@ -522,6 +526,10 @@ object IvyActions {
     resolveOptions.setArtifactFilter(updateConfiguration.artifactFilter)
     resolveOptions.setUseCacheOnly(updateConfiguration.offline)
     resolveOptions.setLog(ivyLogLevel(updateConfiguration.logging))
+    if (updateConfiguration.frozen) {
+      resolveOptions.setTransitive(false)
+      resolveOptions.setCheckIfChanged(false)
+    }
     val acceptError = updateConfiguration.missingOk
     resolver.customResolve(descriptor, acceptError, logicalClock, resolveOptions, cache, log)
   }

--- a/librarymanagement/src/main/scala/sbt/internal/librarymanagement/IvyCache.scala
+++ b/librarymanagement/src/main/scala/sbt/internal/librarymanagement/IvyCache.scala
@@ -108,7 +108,6 @@ class IvyCache(val ivyHome: Option[File]) {
       Vector(local),
       Vector.empty,
       Vector.empty,
-      false,
       lock,
       IvySbt.DefaultChecksums,
       None,

--- a/librarymanagement/src/main/scala/sbt/librarymanagement/DefaultLibraryManagement.scala
+++ b/librarymanagement/src/main/scala/sbt/librarymanagement/DefaultLibraryManagement.scala
@@ -69,6 +69,7 @@ class DefaultLibraryManagement(ivyConfiguration: IvyConfiguration, log: Logger)
       true,
       UpdateLogging.DownloadOnly,
       artifactFilter,
+      false,
       false
     )
 

--- a/librarymanagement/src/main/scala/sbt/librarymanagement/DefaultLibraryManagement.scala
+++ b/librarymanagement/src/main/scala/sbt/librarymanagement/DefaultLibraryManagement.scala
@@ -68,7 +68,8 @@ class DefaultLibraryManagement(ivyConfiguration: IvyConfiguration, log: Logger)
       Some(retrieveConfiguration),
       true,
       UpdateLogging.DownloadOnly,
-      artifactFilter
+      artifactFilter,
+      false
     )
 
     log.debug(s"Attempting to fetch ${dependenciesNames(module)}. This operation may fail.")

--- a/librarymanagement/src/test/scala/BaseIvySpecification.scala
+++ b/librarymanagement/src/test/scala/BaseIvySpecification.scala
@@ -74,7 +74,8 @@ trait BaseIvySpecification extends UnitSpec {
                         false,
                         UpdateLogging.Full,
                         ArtifactTypeFilter.forbid(Set("src", "doc")),
-                        offline)
+                        offline,
+                        false)
   }
 
   def ivyUpdateEither(module: IvySbt#Module): Either[UnresolvedWarning, UpdateReport] = {

--- a/librarymanagement/src/test/scala/BaseIvySpecification.scala
+++ b/librarymanagement/src/test/scala/BaseIvySpecification.scala
@@ -54,14 +54,12 @@ trait BaseIvySpecification extends UnitSpec {
     val paths = IvyPaths(currentBase, Some(currentTarget))
     val other = Vector.empty
     val moduleConfs = Vector(ModuleConfiguration("*", chainResolver))
-    val off = false
     val check = Vector.empty
     val resCacheDir = currentTarget / "resolution-cache"
     new InlineIvyConfiguration(paths,
                                resolvers,
                                other,
                                moduleConfs,
-                               off,
                                None,
                                check,
                                Some(resCacheDir),

--- a/librarymanagement/src/test/scala/BaseIvySpecification.scala
+++ b/librarymanagement/src/test/scala/BaseIvySpecification.scala
@@ -69,18 +69,19 @@ trait BaseIvySpecification extends UnitSpec {
                                log)
   }
 
-  def makeUpdateConfiguration: UpdateConfiguration = {
+  def makeUpdateConfiguration(offline: Boolean): UpdateConfiguration = {
     val retrieveConfig =
       RetrieveConfiguration(currentManaged, Resolver.defaultRetrievePattern).withSync(false)
     UpdateConfiguration(Some(retrieveConfig),
                         false,
                         UpdateLogging.Full,
-                        ArtifactTypeFilter.forbid(Set("src", "doc")))
+                        ArtifactTypeFilter.forbid(Set("src", "doc")),
+                        offline)
   }
 
   def ivyUpdateEither(module: IvySbt#Module): Either[UnresolvedWarning, UpdateReport] = {
     // IO.delete(currentTarget)
-    val config = makeUpdateConfiguration
+    val config = makeUpdateConfiguration(false)
     IvyActions.updateEither(module,
                             config,
                             UnresolvedWarningConfiguration(),

--- a/librarymanagement/src/test/scala/CustomPomParserTest.scala
+++ b/librarymanagement/src/test/scala/CustomPomParserTest.scala
@@ -19,7 +19,6 @@ class CustomPomParserTest extends UnitSpec {
                                             Vector(local),
                                             Vector.empty,
                                             Vector.empty,
-                                            false,
                                             None,
                                             Vector("sha1", "md5"),
                                             None,

--- a/librarymanagement/src/test/scala/FrozenModeSpec.scala
+++ b/librarymanagement/src/test/scala/FrozenModeSpec.scala
@@ -1,0 +1,33 @@
+package sbt.librarymanagement
+
+import sbt.internal.librarymanagement._
+import sbt.internal.librarymanagement.impl.DependencyBuilders
+
+class FrozenModeSpec extends BaseIvySpecification with DependencyBuilders {
+  private final val targetDir = Some(currentDependency)
+  private final val onlineConf = makeUpdateConfiguration(false)
+  private final val frozenConf = makeUpdateConfiguration(false).withFrozen(true)
+  private final val noClock = LogicalClock.unknown
+  private final val warningConf = UnresolvedWarningConfiguration()
+  private final val normalOptions = UpdateOptions()
+  private final val cachedOptions = UpdateOptions().withCachedResolution(true)
+
+  final val stoml = Vector("me.vican.jorge" % "stoml_2.12" % "0.4" % "compile")
+
+  it should "fail when artifacts are missing in the cache" in {
+    cleanIvyCache()
+    val toResolve = module(defaultModuleId, stoml, None, normalOptions)
+    def update(conf: UpdateConfiguration) =
+      IvyActions.updateEither(toResolve, conf, warningConf, noClock, targetDir, log)
+
+    val onlineResolution = update(onlineConf)
+    assert(onlineResolution.isRight)
+    val numberResolved = onlineResolution.right.get.allModules.size
+
+    // This relies on the fact that stoml has 5 transitive dependencies
+    val frozenResolution = update(frozenConf)
+    assert(frozenResolution.isRight)
+    assert(frozenResolution.get.allModules.size == numberResolved,
+           s"The number of resolved modules in frozen mode should be less than $numberResolved")
+  }
+}

--- a/librarymanagement/src/test/scala/OfflineModeSpec.scala
+++ b/librarymanagement/src/test/scala/OfflineModeSpec.scala
@@ -1,0 +1,69 @@
+package sbt.librarymanagement
+
+import org.scalatest.Assertion
+import sbt.internal.librarymanagement._
+import sbt.internal.librarymanagement.impl.DependencyBuilders
+
+class OfflineModeSpec extends BaseIvySpecification with DependencyBuilders {
+  private final val targetDir = Some(currentDependency)
+  private final val onlineConf = makeUpdateConfiguration(false)
+  private final val offlineConf = makeUpdateConfiguration(true)
+  private final val noClock = LogicalClock.unknown
+  private final val warningConf = UnresolvedWarningConfiguration()
+  private final val normalOptions = UpdateOptions()
+  private final val cachedOptions = UpdateOptions().withCachedResolution(true)
+
+  final val scalaCompiler = Vector("org.scala-lang" % "scala-compiler" % "2.12.2" % "compile")
+
+  def checkOnlineAndOfflineResolution(updateOptions: UpdateOptions): Assertion = {
+    cleanIvyCache()
+
+    val toResolve = module(defaultModuleId, scalaCompiler, None, updateOptions)
+    val isCachedResolution = updateOptions.cachedResolution
+    if (isCachedResolution) cleanCachedResolutionCache(toResolve)
+
+    val onlineResolution =
+      IvyActions.updateEither(toResolve, onlineConf, warningConf, noClock, targetDir, log)
+    assert(onlineResolution.isRight)
+    assert(onlineResolution.right.exists(report => report.stats.resolveTime > 0))
+
+    // Compute an estimate to ensure that the second resolution does indeed use the cache
+    val resolutionTime: Long = onlineResolution.right.map(_.stats.resolveTime).getOrElse(0L)
+    val estimatedCachedTime = resolutionTime * 0.15
+
+    val offlineResolution =
+      IvyActions.updateEither(toResolve, offlineConf, warningConf, noClock, targetDir, log)
+    assert(offlineResolution.isRight)
+
+    if (!isCachedResolution) {
+      // Only check the estimate for the non cached resolution, otherwise resolution is cached
+      assert(offlineResolution.right.exists(_.stats.resolveTime <= estimatedCachedTime),
+             "Offline resolution took more than 15% of normal resolution's running time.")
+    } else assert(true) // We cannot check offline resolution if it's cached.
+  }
+
+  "Offline update configuration" should "reuse the caches when it's enabled" in {
+    checkOnlineAndOfflineResolution(normalOptions)
+  }
+
+  it should "work with cached resolution" in {
+    checkOnlineAndOfflineResolution(cachedOptions)
+  }
+
+  def checkFailingResolution(updateOptions: UpdateOptions): Assertion = {
+    cleanIvyCache()
+    val toResolve = module(defaultModuleId, scalaCompiler, None, updateOptions)
+    if (updateOptions.cachedResolution) cleanCachedResolutionCache(toResolve)
+    val failedOfflineResolution =
+      IvyActions.updateEither(toResolve, offlineConf, warningConf, noClock, targetDir, log)
+    assert(failedOfflineResolution.isLeft)
+  }
+
+  it should "fail when artifacts are missing in the cache" in {
+    checkFailingResolution(normalOptions)
+  }
+
+  it should "fail when artifacts are missing in the cache for cached resolution" in {
+    checkFailingResolution(cachedOptions)
+  }
+}

--- a/librarymanagement/src/test/scala/sbt/internal/librarymanagement/IvyRepoSpec.scala
+++ b/librarymanagement/src/test/scala/sbt/internal/librarymanagement/IvyRepoSpec.scala
@@ -44,7 +44,7 @@ class IvyRepoSpec extends BaseIvySpecification with DependencyBuilders {
     val m = makeModuleForDepWithSources
 
     // the "default" configuration used in updateEither.
-    val c = makeUpdateConfiguration
+    val c = makeUpdateConfiguration(false)
 
     val ivyScala = m.moduleSettings.ivyScala
     val srcTypes = Set("src")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -51,7 +51,7 @@ object Dependencies {
   def addSbtUtilCache(p: Project): Project = addSbtModule(p, sbtUtilPath, "utilCache", utilCache)
 
   val launcherInterface = "org.scala-sbt" % "launcher-interface" % "1.0.0"
-  val ivy = "org.scala-sbt.ivy" % "ivy" % "2.3.0-sbt-48dd0744422128446aee9ac31aa356ee203cc9f4"
+  val ivy = "org.scala-sbt.ivy" % "ivy" % "2.3.0-sbt-a3314352b638afbf0dca19f127e8263ed6f898bd"
   val jsch = "com.jcraft" % "jsch" % "0.1.46" intransitive ()
   val scalaReflect = Def.setting { "org.scala-lang" % "scala-reflect" % scalaVersion.value }
   val scalaXml = scala211Module("scala-xml", "1.0.5")


### PR DESCRIPTION
The frozen mode is a new addition for the dependency lock file.

Under this mode, ivy will make sure that transitive dependencies are disabled
at the resolver level, and not at the dependency level. So any attempt to
resolve transitively will fail -- the frozen mode assumes explicitly listed
dependencies.

This depends on https://github.com/sbt/librarymanagement/pull/92.
I'll rebase when the dependent is merged.