### PR TITLE
Allow to define concrete resolvers for dependencies

### DIFF
--- a/librarymanagement/src/main/scala/sbt/internal/librarymanagement/formats/UpdateOptionsFormat.scala
+++ b/librarymanagement/src/main/scala/sbt/internal/librarymanagement/formats/UpdateOptionsFormat.scala
@@ -4,7 +4,18 @@ package formats
 import sjsonnew._
 import sbt.librarymanagement._
 
-trait UpdateOptionsFormat { self: BasicJsonProtocol =>
+trait UpdateOptionsFormat { self: BasicJsonProtocol with ModuleIDFormats with ResolverFormats =>
+  /* This is necessary to serialize/deserialize `directResolvers`. */
+  private implicit val moduleIdJsonKeyFormat: sjsonnew.JsonKeyFormat[ModuleID] = {
+    new sjsonnew.JsonKeyFormat[ModuleID] {
+      import sjsonnew.support.scalajson.unsafe._
+      val moduleIdFormat: JsonFormat[ModuleID] = implicitly[JsonFormat[ModuleID]]
+      def write(key: ModuleID): String =
+        CompactPrinter(Converter.toJsonUnsafe(key)(moduleIdFormat))
+      def read(key: String): ModuleID =
+        Converter.fromJsonUnsafe[ModuleID](Parser.parseUnsafe(key))(moduleIdFormat)
+    }
+  }
 
   implicit lazy val UpdateOptionsFormat: JsonFormat[UpdateOptions] =
     project(
@@ -14,16 +25,18 @@ trait UpdateOptionsFormat { self: BasicJsonProtocol =>
           uo.interProjectFirst,
           uo.latestSnapshots,
           uo.consolidatedResolution,
-          uo.cachedResolution
+          uo.cachedResolution,
+          uo.moduleResolvers
       ),
-      (xs: (String, Boolean, Boolean, Boolean, Boolean)) =>
+      (xs: (String, Boolean, Boolean, Boolean, Boolean, Map[ModuleID, Resolver])) =>
         new UpdateOptions(
           levels(xs._1),
           xs._2,
           xs._3,
           xs._4,
           xs._5,
-          ConvertResolver.defaultConvert
+          ConvertResolver.defaultConvert,
+          xs._6
       )
     )
 

--- a/librarymanagement/src/main/scala/sbt/librarymanagement/UpdateOptions.scala
+++ b/librarymanagement/src/main/scala/sbt/librarymanagement/UpdateOptions.scala
@@ -23,7 +23,9 @@ final class UpdateOptions private[sbt] (
     // If set to true, use cached resolution.
     val cachedResolution: Boolean,
     // Extension point for an alternative resolver converter.
-    val resolverConverter: UpdateOptions.ResolverConverter
+    val resolverConverter: UpdateOptions.ResolverConverter,
+    // Map the unique resolver to be checked for the module ID
+    val moduleResolvers: Map[ModuleID, Resolver]
 ) {
   def withCircularDependencyLevel(
       circularDependencyLevel: CircularDependencyLevel
@@ -49,13 +51,17 @@ final class UpdateOptions private[sbt] (
   def withResolverConverter(resolverConverter: UpdateOptions.ResolverConverter): UpdateOptions =
     copy(resolverConverter = resolverConverter)
 
+  def withModuleResolvers(moduleResolvers: Map[ModuleID, Resolver]): UpdateOptions =
+    copy(moduleResolvers = moduleResolvers)
+
   private[sbt] def copy(
       circularDependencyLevel: CircularDependencyLevel = this.circularDependencyLevel,
       interProjectFirst: Boolean = this.interProjectFirst,
       latestSnapshots: Boolean = this.latestSnapshots,
       consolidatedResolution: Boolean = this.consolidatedResolution,
       cachedResolution: Boolean = this.cachedResolution,
-      resolverConverter: UpdateOptions.ResolverConverter = this.resolverConverter
+      resolverConverter: UpdateOptions.ResolverConverter = this.resolverConverter,
+      moduleResolvers: Map[ModuleID, Resolver] = this.moduleResolvers
   ): UpdateOptions =
     new UpdateOptions(
       circularDependencyLevel,
@@ -63,7 +69,8 @@ final class UpdateOptions private[sbt] (
       latestSnapshots,
       consolidatedResolution,
       cachedResolution,
-      resolverConverter
+      resolverConverter,
+      moduleResolvers
     )
 
   override def equals(o: Any): Boolean = o match {
@@ -72,7 +79,8 @@ final class UpdateOptions private[sbt] (
         this.interProjectFirst == o.interProjectFirst &&
         this.latestSnapshots == o.latestSnapshots &&
         this.cachedResolution == o.cachedResolution &&
-        this.resolverConverter == o.resolverConverter
+        this.resolverConverter == o.resolverConverter &&
+        this.moduleResolvers == o.moduleResolvers
     case _ => false
   }
 
@@ -83,6 +91,7 @@ final class UpdateOptions private[sbt] (
     hash = hash * 31 + this.latestSnapshots.##
     hash = hash * 31 + this.cachedResolution.##
     hash = hash * 31 + this.resolverConverter.##
+    hash = hash * 31 + this.moduleResolvers.##
     hash
   }
 }
@@ -97,6 +106,7 @@ object UpdateOptions {
       latestSnapshots = true,
       consolidatedResolution = false,
       cachedResolution = false,
-      resolverConverter = PartialFunction.empty
+      resolverConverter = PartialFunction.empty,
+      moduleResolvers = Map.empty
     )
 }

--- a/librarymanagement/src/test/scala/ModuleResolversTest.scala
+++ b/librarymanagement/src/test/scala/ModuleResolversTest.scala
@@ -1,0 +1,48 @@
+package sbt.librarymanagement
+
+import sbt.internal.librarymanagement.BaseIvySpecification
+import sbt.internal.librarymanagement.impl.DependencyBuilders
+
+class ModuleResolversTest extends BaseIvySpecification with DependencyBuilders {
+  override final val resolvers = Vector(
+    DefaultMavenRepository,
+    JavaNet2Repository,
+    JCenterRepository,
+    Resolver.sbtPluginRepo("releases")
+  )
+
+  private final val stubModule = "com.example" % "foo" % "0.1.0" % "compile"
+  val pluginAttributes = Map("sbtVersion" -> "0.13", "scalaVersion" -> "2.10")
+  private final val dependencies = Vector(
+    ("me.lessis" % "bintray-sbt" % "0.3.0" % "compile").withExtraAttributes(pluginAttributes),
+    "com.jfrog.bintray.client" % "bintray-client-java-api" % "0.9.2" % "compile"
+  ).map(_.withIsTransitive(false))
+
+  "The direct resolvers in update options" should "skip the rest of resolvers" in {
+    cleanIvyCache()
+    val updateOptions = UpdateOptions()
+    val ivyModule = module(stubModule, dependencies, None, updateOptions)
+    val normalResolution = ivyUpdateEither(ivyModule)
+    assert(normalResolution.isRight)
+    val normalResolutionTime = normalResolution.right.get.stats.resolveTime
+
+    cleanIvyCache()
+    val moduleResolvers = Map(
+      dependencies.head -> resolvers.last,
+      dependencies.tail.head -> resolvers.init.last
+    )
+    val customUpdateOptions = updateOptions.withModuleResolvers(moduleResolvers)
+    val ivyModule2 = module(stubModule, dependencies, None, customUpdateOptions)
+    val fasterResolution = ivyUpdateEither(ivyModule2)
+    assert(fasterResolution.isRight)
+    val fasterResolutionTime = fasterResolution.right.get.stats.resolveTime
+
+    // THis is left on purpose so that in spurious error we see the times
+    println(s"NORMAL RESOLUTION TIME $normalResolutionTime")
+    println(s"FASTER RESOLUTION TIME $fasterResolutionTime")
+
+    // Check that faster resolution is at least 1/5 faster than normal resolution
+    // This is a conservative check just to make sure we don't regress -- speedup is higher
+    assert(fasterResolutionTime <= (normalResolutionTime * 0.80))
+  }
+}


### PR DESCRIPTION
This depends on https://github.com/sbt/librarymanagement/pull/96/files.
    
Sometimes, for predictability and performance, we may be interested in
specifying the concrete resolver that a `ModuleID` should use.

This patch achieves this by adding a new field to `UpdateOptions` and
then getting this information from the `SbtChainResolver`, that will
select the concrete resolver for a given dependency descriptor.

Why is this useful? Well, two reasons:

* Predictable behaviour. We have the guarantee that an artifact only
  comes from a concrete resolver.
* Resolution speedup. Around 1/3 or 1/2 times faster than normal
  resolution in a moderate test case scenario. If there is a lot of
  latency or network connection is poor, speedups will be higher.

Some results of tests I have just ran:

```
NORMAL RESOLUTION TIME 1790
FASTER RESOLUTION TIME 1054
```

```
NORMAL RESOLUTION TIME 2078
FASTER RESOLUTION TIME 1055
```

Lots of projects can benefit from this option, as well as organizations
and companies. This will eventually integrate with the dependency lock
file, but can be used independently of it.