### PR TITLE
[fport] Fix default scalaBinaryVersion for Dotty

### DIFF
--- a/librarymanagement/src/main/scala/sbt/internal/librarymanagement/cross/CrossVersionUtil.scala
+++ b/librarymanagement/src/main/scala/sbt/internal/librarymanagement/cross/CrossVersionUtil.scala
@@ -8,7 +8,8 @@ object CrossVersionUtil {
   val noneString = "none"
   val disabledString = "disabled"
   val binaryString = "binary"
-  val TransitionScalaVersion = "2.10"
+  val TransitionDottyVersion = "" // Dotty always respects binary compatibility
+  val TransitionScalaVersion = "2.10" // ...but scalac doesn't until Scala 2.10
   val TransitionSbtVersion = "0.12"
 
   def isFull(s: String): Boolean = (s == trueString) || (s == fullString)
@@ -61,8 +62,15 @@ object CrossVersionUtil {
       case PartialVersion(major, minor) => Some((major.toInt, minor.toInt))
       case _                            => None
     }
-  def binaryScalaVersion(full: String): String =
-    binaryVersionWithApi(full, TransitionScalaVersion)(scalaApiVersion)
+  def binaryScalaVersion(full: String): String = {
+    val cutoff =
+      if (full.startsWith("0."))
+        TransitionDottyVersion
+      else
+        TransitionScalaVersion
+
+    binaryVersionWithApi(full, cutoff)(scalaApiVersion)
+  }
   def binarySbtVersion(full: String): String =
     binaryVersionWithApi(full, TransitionSbtVersion)(sbtApiVersion)
   private[sbt] def binaryVersion(full: String, cutoff: String): String =

--- a/librarymanagement/src/test/scala/CrossVersionTest.scala
+++ b/librarymanagement/src/test/scala/CrossVersionTest.scala
@@ -117,6 +117,9 @@ class CrossVersionTest extends UnitSpec {
   it should "return binary Scala version for 2.20170314093845.0-87654321 as 2.20170314093845.0-87654321" in {
     CrossVersion.binaryScalaVersion("2.20170314093845.0-87654321") shouldBe "2.20170314093845.0-87654321"
   }
+  it should "return binary Scala version for Dotty 0.1.1 as 0.1" in {
+    CrossVersion.binaryScalaVersion("0.1.1") shouldBe "0.1"
+  }
   it should "return patch Scala version for 2.11.8 as 2.11.8" in {
     CrossVersion(CrossVersion.patch, "2.11.8", "dummy").map(_("artefact")) shouldBe Some(
       "artefact_2.11.8")


### PR DESCRIPTION
This is a forward port of https://github.com/sbt/sbt/pull/3152

Dotty is versioned as 0.*, but `CrossVersionUtil#binaryScalaVersion`
will return the full version instead of just `major.minor` for all
compiler versions < 2.10, add a special case for Dotty to avoid this.