### PR TITLE
Fix sbt/sbt#3226: Use `ConvertResolver.default`

### DIFF
--- a/librarymanagement/src/main/scala/sbt/internal/librarymanagement/formats/UpdateOptionsFormat.scala
+++ b/librarymanagement/src/main/scala/sbt/internal/librarymanagement/formats/UpdateOptionsFormat.scala
@@ -35,7 +35,8 @@ trait UpdateOptionsFormat { self: BasicJsonProtocol with ModuleIDFormats with Re
           xs._3,
           xs._4,
           xs._5,
-          PartialFunction.empty,
+          // Default to the default resolver so that caching works
+          ConvertResolver.defaultConvert,
           xs._6
       )
     )


### PR DESCRIPTION
Sbt expects this to be the default that is used for caching update.