### PR TITLE
define def config(...) as a macro to capture the Scala identifier

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -72,7 +72,8 @@ lazy val lm = (project in file("librarymanagement"))
                                 gigahorseOkhttp,
                                 okhttpUrlconnection,
                                 sjsonnewScalaJson.value % Optional,
-                                scalaTest),
+                                scalaTest,
+                                scalaCheck),
     libraryDependencies ++= scalaXml.value,
     resourceGenerators in Compile += Def.task(
       Util.generateVersionFile(

--- a/build.sbt
+++ b/build.sbt
@@ -64,11 +64,15 @@ lazy val lm = (project in file("librarymanagement"))
   .settings(
     commonSettings,
     name := "librarymanagement",
-    libraryDependencies ++= Seq(
-      ivy, jsch, scalaReflect.value, launcherInterface, gigahorseOkhttp, okhttpUrlconnection,
-      sjsonnewScalaJson.value % Optional,
-      scalaTest
-    ),
+    libraryDependencies ++= Seq(ivy,
+                                jsch,
+                                scalaReflect.value,
+                                scalaCompiler.value,
+                                launcherInterface,
+                                gigahorseOkhttp,
+                                okhttpUrlconnection,
+                                sjsonnewScalaJson.value % Optional,
+                                scalaTest),
     libraryDependencies ++= scalaXml.value,
     resourceGenerators in Compile += Def.task(
       Util.generateVersionFile(

--- a/librarymanagement/src/main/contraband-scala/sbt/internal/librarymanagement/RetrieveConfiguration.scala
+++ b/librarymanagement/src/main/contraband-scala/sbt/internal/librarymanagement/RetrieveConfiguration.scala
@@ -8,7 +8,7 @@ final class RetrieveConfiguration private (
   val retrieveDirectory: java.io.File,
   val outputPattern: String,
   val sync: Boolean,
-  val configurationsToRetrieve: Option[Set[sbt.librarymanagement.Configuration]]) extends Serializable {
+  val configurationsToRetrieve: Option[Set[sbt.librarymanagement.ConfigRef]]) extends Serializable {
   
   private def this(retrieveDirectory: java.io.File, outputPattern: String) = this(retrieveDirectory, outputPattern, false, None)
   
@@ -22,7 +22,7 @@ final class RetrieveConfiguration private (
   override def toString: String = {
     "RetrieveConfiguration(" + retrieveDirectory + ", " + outputPattern + ", " + sync + ", " + configurationsToRetrieve + ")"
   }
-  protected[this] def copy(retrieveDirectory: java.io.File = retrieveDirectory, outputPattern: String = outputPattern, sync: Boolean = sync, configurationsToRetrieve: Option[Set[sbt.librarymanagement.Configuration]] = configurationsToRetrieve): RetrieveConfiguration = {
+  protected[this] def copy(retrieveDirectory: java.io.File = retrieveDirectory, outputPattern: String = outputPattern, sync: Boolean = sync, configurationsToRetrieve: Option[Set[sbt.librarymanagement.ConfigRef]] = configurationsToRetrieve): RetrieveConfiguration = {
     new RetrieveConfiguration(retrieveDirectory, outputPattern, sync, configurationsToRetrieve)
   }
   def withRetrieveDirectory(retrieveDirectory: java.io.File): RetrieveConfiguration = {
@@ -34,12 +34,12 @@ final class RetrieveConfiguration private (
   def withSync(sync: Boolean): RetrieveConfiguration = {
     copy(sync = sync)
   }
-  def withConfigurationsToRetrieve(configurationsToRetrieve: Option[Set[sbt.librarymanagement.Configuration]]): RetrieveConfiguration = {
+  def withConfigurationsToRetrieve(configurationsToRetrieve: Option[Set[sbt.librarymanagement.ConfigRef]]): RetrieveConfiguration = {
     copy(configurationsToRetrieve = configurationsToRetrieve)
   }
 }
 object RetrieveConfiguration {
   
   def apply(retrieveDirectory: java.io.File, outputPattern: String): RetrieveConfiguration = new RetrieveConfiguration(retrieveDirectory, outputPattern, false, None)
-  def apply(retrieveDirectory: java.io.File, outputPattern: String, sync: Boolean, configurationsToRetrieve: Option[Set[sbt.librarymanagement.Configuration]]): RetrieveConfiguration = new RetrieveConfiguration(retrieveDirectory, outputPattern, sync, configurationsToRetrieve)
+  def apply(retrieveDirectory: java.io.File, outputPattern: String, sync: Boolean, configurationsToRetrieve: Option[Set[sbt.librarymanagement.ConfigRef]]): RetrieveConfiguration = new RetrieveConfiguration(retrieveDirectory, outputPattern, sync, configurationsToRetrieve)
 }

--- a/librarymanagement/src/main/contraband-scala/sbt/librarymanagement/Artifact.scala
+++ b/librarymanagement/src/main/contraband-scala/sbt/librarymanagement/Artifact.scala
@@ -9,7 +9,7 @@ final class Artifact private (
   val `type`: String,
   val extension: String,
   val classifier: Option[String],
-  val configurations: Vector[String],
+  val configurations: Vector[sbt.librarymanagement.ConfigRef],
   val url: Option[java.net.URL],
   val extraAttributes: Map[String, String],
   val checksum: Option[sbt.librarymanagement.Checksum]) extends sbt.librarymanagement.ArtifactExtra with Serializable {
@@ -26,7 +26,7 @@ final class Artifact private (
   override def toString: String = {
     "Artifact(" + name + ", " + `type` + ", " + extension + ", " + classifier + ", " + configurations + ", " + url + ", " + extraAttributes + ", " + checksum + ")"
   }
-  protected[this] def copy(name: String = name, `type`: String = `type`, extension: String = extension, classifier: Option[String] = classifier, configurations: Vector[String] = configurations, url: Option[java.net.URL] = url, extraAttributes: Map[String, String] = extraAttributes, checksum: Option[sbt.librarymanagement.Checksum] = checksum): Artifact = {
+  protected[this] def copy(name: String = name, `type`: String = `type`, extension: String = extension, classifier: Option[String] = classifier, configurations: Vector[sbt.librarymanagement.ConfigRef] = configurations, url: Option[java.net.URL] = url, extraAttributes: Map[String, String] = extraAttributes, checksum: Option[sbt.librarymanagement.Checksum] = checksum): Artifact = {
     new Artifact(name, `type`, extension, classifier, configurations, url, extraAttributes, checksum)
   }
   def withName(name: String): Artifact = {
@@ -41,7 +41,7 @@ final class Artifact private (
   def withClassifier(classifier: Option[String]): Artifact = {
     copy(classifier = classifier)
   }
-  def withConfigurations(configurations: Vector[String]): Artifact = {
+  def withConfigurations(configurations: Vector[sbt.librarymanagement.ConfigRef]): Artifact = {
     copy(configurations = configurations)
   }
   def withUrl(url: Option[java.net.URL]): Artifact = {
@@ -57,5 +57,5 @@ final class Artifact private (
 object Artifact extends sbt.librarymanagement.ArtifactFunctions {
   
   def apply(name: String): Artifact = new Artifact(name, Artifact.DefaultType, Artifact.DefaultExtension, None, Vector.empty, None, Map.empty, None)
-  def apply(name: String, `type`: String, extension: String, classifier: Option[String], configurations: Vector[String], url: Option[java.net.URL], extraAttributes: Map[String, String], checksum: Option[sbt.librarymanagement.Checksum]): Artifact = new Artifact(name, `type`, extension, classifier, configurations, url, extraAttributes, checksum)
+  def apply(name: String, `type`: String, extension: String, classifier: Option[String], configurations: Vector[sbt.librarymanagement.ConfigRef], url: Option[java.net.URL], extraAttributes: Map[String, String], checksum: Option[sbt.librarymanagement.Checksum]): Artifact = new Artifact(name, `type`, extension, classifier, configurations, url, extraAttributes, checksum)
 }

--- a/librarymanagement/src/main/contraband-scala/sbt/librarymanagement/Artifact.scala
+++ b/librarymanagement/src/main/contraband-scala/sbt/librarymanagement/Artifact.scala
@@ -9,7 +9,7 @@ final class Artifact private (
   val `type`: String,
   val extension: String,
   val classifier: Option[String],
-  val configurations: Vector[sbt.librarymanagement.Configuration],
+  val configurations: Vector[String],
   val url: Option[java.net.URL],
   val extraAttributes: Map[String, String],
   val checksum: Option[sbt.librarymanagement.Checksum]) extends sbt.librarymanagement.ArtifactExtra with Serializable {
@@ -26,7 +26,7 @@ final class Artifact private (
   override def toString: String = {
     "Artifact(" + name + ", " + `type` + ", " + extension + ", " + classifier + ", " + configurations + ", " + url + ", " + extraAttributes + ", " + checksum + ")"
   }
-  protected[this] def copy(name: String = name, `type`: String = `type`, extension: String = extension, classifier: Option[String] = classifier, configurations: Vector[sbt.librarymanagement.Configuration] = configurations, url: Option[java.net.URL] = url, extraAttributes: Map[String, String] = extraAttributes, checksum: Option[sbt.librarymanagement.Checksum] = checksum): Artifact = {
+  protected[this] def copy(name: String = name, `type`: String = `type`, extension: String = extension, classifier: Option[String] = classifier, configurations: Vector[String] = configurations, url: Option[java.net.URL] = url, extraAttributes: Map[String, String] = extraAttributes, checksum: Option[sbt.librarymanagement.Checksum] = checksum): Artifact = {
     new Artifact(name, `type`, extension, classifier, configurations, url, extraAttributes, checksum)
   }
   def withName(name: String): Artifact = {
@@ -41,7 +41,7 @@ final class Artifact private (
   def withClassifier(classifier: Option[String]): Artifact = {
     copy(classifier = classifier)
   }
-  def withConfigurations(configurations: Vector[sbt.librarymanagement.Configuration]): Artifact = {
+  def withConfigurations(configurations: Vector[String]): Artifact = {
     copy(configurations = configurations)
   }
   def withUrl(url: Option[java.net.URL]): Artifact = {
@@ -57,5 +57,5 @@ final class Artifact private (
 object Artifact extends sbt.librarymanagement.ArtifactFunctions {
   
   def apply(name: String): Artifact = new Artifact(name, Artifact.DefaultType, Artifact.DefaultExtension, None, Vector.empty, None, Map.empty, None)
-  def apply(name: String, `type`: String, extension: String, classifier: Option[String], configurations: Vector[sbt.librarymanagement.Configuration], url: Option[java.net.URL], extraAttributes: Map[String, String], checksum: Option[sbt.librarymanagement.Checksum]): Artifact = new Artifact(name, `type`, extension, classifier, configurations, url, extraAttributes, checksum)
+  def apply(name: String, `type`: String, extension: String, classifier: Option[String], configurations: Vector[String], url: Option[java.net.URL], extraAttributes: Map[String, String], checksum: Option[sbt.librarymanagement.Checksum]): Artifact = new Artifact(name, `type`, extension, classifier, configurations, url, extraAttributes, checksum)
 }

--- a/librarymanagement/src/main/contraband-scala/sbt/librarymanagement/ArtifactFormats.scala
+++ b/librarymanagement/src/main/contraband-scala/sbt/librarymanagement/ArtifactFormats.scala
@@ -5,7 +5,7 @@
 // DO NOT EDIT MANUALLY
 package sbt.librarymanagement
 import _root_.sjsonnew.{ Unbuilder, Builder, JsonFormat, deserializationError }
-trait ArtifactFormats { self: sbt.librarymanagement.ChecksumFormats with sjsonnew.BasicJsonProtocol =>
+trait ArtifactFormats { self: sbt.librarymanagement.ConfigRefFormats with sbt.librarymanagement.ChecksumFormats with sjsonnew.BasicJsonProtocol =>
 implicit lazy val ArtifactFormat: JsonFormat[sbt.librarymanagement.Artifact] = new JsonFormat[sbt.librarymanagement.Artifact] {
   override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): sbt.librarymanagement.Artifact = {
     jsOpt match {
@@ -15,7 +15,7 @@ implicit lazy val ArtifactFormat: JsonFormat[sbt.librarymanagement.Artifact] = n
       val `type` = unbuilder.readField[String]("type")
       val extension = unbuilder.readField[String]("extension")
       val classifier = unbuilder.readField[Option[String]]("classifier")
-      val configurations = unbuilder.readField[Vector[String]]("configurations")
+      val configurations = unbuilder.readField[Vector[sbt.librarymanagement.ConfigRef]]("configurations")
       val url = unbuilder.readField[Option[java.net.URL]]("url")
       val extraAttributes = unbuilder.readField[Map[String, String]]("extraAttributes")
       val checksum = unbuilder.readField[Option[sbt.librarymanagement.Checksum]]("checksum")

--- a/librarymanagement/src/main/contraband-scala/sbt/librarymanagement/ArtifactFormats.scala
+++ b/librarymanagement/src/main/contraband-scala/sbt/librarymanagement/ArtifactFormats.scala
@@ -5,7 +5,7 @@
 // DO NOT EDIT MANUALLY
 package sbt.librarymanagement
 import _root_.sjsonnew.{ Unbuilder, Builder, JsonFormat, deserializationError }
-trait ArtifactFormats { self: sbt.librarymanagement.ConfigurationFormats with sbt.librarymanagement.ChecksumFormats with sjsonnew.BasicJsonProtocol =>
+trait ArtifactFormats { self: sbt.librarymanagement.ChecksumFormats with sjsonnew.BasicJsonProtocol =>
 implicit lazy val ArtifactFormat: JsonFormat[sbt.librarymanagement.Artifact] = new JsonFormat[sbt.librarymanagement.Artifact] {
   override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): sbt.librarymanagement.Artifact = {
     jsOpt match {
@@ -15,7 +15,7 @@ implicit lazy val ArtifactFormat: JsonFormat[sbt.librarymanagement.Artifact] = n
       val `type` = unbuilder.readField[String]("type")
       val extension = unbuilder.readField[String]("extension")
       val classifier = unbuilder.readField[Option[String]]("classifier")
-      val configurations = unbuilder.readField[Vector[sbt.librarymanagement.Configuration]]("configurations")
+      val configurations = unbuilder.readField[Vector[String]]("configurations")
       val url = unbuilder.readField[Option[java.net.URL]]("url")
       val extraAttributes = unbuilder.readField[Map[String, String]]("extraAttributes")
       val checksum = unbuilder.readField[Option[sbt.librarymanagement.Checksum]]("checksum")

--- a/librarymanagement/src/main/contraband-scala/sbt/librarymanagement/Caller.scala
+++ b/librarymanagement/src/main/contraband-scala/sbt/librarymanagement/Caller.scala
@@ -6,7 +6,7 @@
 package sbt.librarymanagement
 final class Caller private (
   val caller: sbt.librarymanagement.ModuleID,
-  val callerConfigurations: Vector[String],
+  val callerConfigurations: Vector[sbt.librarymanagement.ConfigRef],
   val callerExtraAttributes: Map[String, String],
   val isForceDependency: Boolean,
   val isChangingDependency: Boolean,
@@ -25,13 +25,13 @@ final class Caller private (
   override def toString: String = {
     s"$caller"
   }
-  protected[this] def copy(caller: sbt.librarymanagement.ModuleID = caller, callerConfigurations: Vector[String] = callerConfigurations, callerExtraAttributes: Map[String, String] = callerExtraAttributes, isForceDependency: Boolean = isForceDependency, isChangingDependency: Boolean = isChangingDependency, isTransitiveDependency: Boolean = isTransitiveDependency, isDirectlyForceDependency: Boolean = isDirectlyForceDependency): Caller = {
+  protected[this] def copy(caller: sbt.librarymanagement.ModuleID = caller, callerConfigurations: Vector[sbt.librarymanagement.ConfigRef] = callerConfigurations, callerExtraAttributes: Map[String, String] = callerExtraAttributes, isForceDependency: Boolean = isForceDependency, isChangingDependency: Boolean = isChangingDependency, isTransitiveDependency: Boolean = isTransitiveDependency, isDirectlyForceDependency: Boolean = isDirectlyForceDependency): Caller = {
     new Caller(caller, callerConfigurations, callerExtraAttributes, isForceDependency, isChangingDependency, isTransitiveDependency, isDirectlyForceDependency)
   }
   def withCaller(caller: sbt.librarymanagement.ModuleID): Caller = {
     copy(caller = caller)
   }
-  def withCallerConfigurations(callerConfigurations: Vector[String]): Caller = {
+  def withCallerConfigurations(callerConfigurations: Vector[sbt.librarymanagement.ConfigRef]): Caller = {
     copy(callerConfigurations = callerConfigurations)
   }
   def withCallerExtraAttributes(callerExtraAttributes: Map[String, String]): Caller = {
@@ -52,5 +52,5 @@ final class Caller private (
 }
 object Caller {
   
-  def apply(caller: sbt.librarymanagement.ModuleID, callerConfigurations: Vector[String], callerExtraAttributes: Map[String, String], isForceDependency: Boolean, isChangingDependency: Boolean, isTransitiveDependency: Boolean, isDirectlyForceDependency: Boolean): Caller = new Caller(caller, callerConfigurations, callerExtraAttributes, isForceDependency, isChangingDependency, isTransitiveDependency, isDirectlyForceDependency)
+  def apply(caller: sbt.librarymanagement.ModuleID, callerConfigurations: Vector[sbt.librarymanagement.ConfigRef], callerExtraAttributes: Map[String, String], isForceDependency: Boolean, isChangingDependency: Boolean, isTransitiveDependency: Boolean, isDirectlyForceDependency: Boolean): Caller = new Caller(caller, callerConfigurations, callerExtraAttributes, isForceDependency, isChangingDependency, isTransitiveDependency, isDirectlyForceDependency)
 }

--- a/librarymanagement/src/main/contraband-scala/sbt/librarymanagement/CallerFormats.scala
+++ b/librarymanagement/src/main/contraband-scala/sbt/librarymanagement/CallerFormats.scala
@@ -5,14 +5,14 @@
 // DO NOT EDIT MANUALLY
 package sbt.librarymanagement
 import _root_.sjsonnew.{ Unbuilder, Builder, JsonFormat, deserializationError }
-trait CallerFormats { self: sbt.librarymanagement.ModuleIDFormats with sjsonnew.BasicJsonProtocol =>
+trait CallerFormats { self: sbt.librarymanagement.ModuleIDFormats with sbt.librarymanagement.ConfigRefFormats with sjsonnew.BasicJsonProtocol =>
 implicit lazy val CallerFormat: JsonFormat[sbt.librarymanagement.Caller] = new JsonFormat[sbt.librarymanagement.Caller] {
   override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): sbt.librarymanagement.Caller = {
     jsOpt match {
       case Some(js) =>
       unbuilder.beginObject(js)
       val caller = unbuilder.readField[sbt.librarymanagement.ModuleID]("caller")
-      val callerConfigurations = unbuilder.readField[Vector[String]]("callerConfigurations")
+      val callerConfigurations = unbuilder.readField[Vector[sbt.librarymanagement.ConfigRef]]("callerConfigurations")
       val callerExtraAttributes = unbuilder.readField[Map[String, String]]("callerExtraAttributes")
       val isForceDependency = unbuilder.readField[Boolean]("isForceDependency")
       val isChangingDependency = unbuilder.readField[Boolean]("isChangingDependency")

--- a/librarymanagement/src/main/contraband-scala/sbt/librarymanagement/ConfigRef.scala
+++ b/librarymanagement/src/main/contraband-scala/sbt/librarymanagement/ConfigRef.scala
@@ -1,0 +1,34 @@
+/**
+ * This code is generated using [[http://www.scala-sbt.org/contraband/ sbt-contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.librarymanagement
+/** A reference to Configuration. */
+final class ConfigRef private (
+  /** The name of the configuration that eventually get used by Maven. */
+  val name: String) extends Serializable {
+  
+  
+  
+  override def equals(o: Any): Boolean = o match {
+    case x: ConfigRef => (this.name == x.name)
+    case _ => false
+  }
+  override def hashCode: Int = {
+    37 * (37 * (17 + "ConfigRef".##) + name.##)
+  }
+  override def toString: String = {
+    "ConfigRef(" + name + ")"
+  }
+  protected[this] def copy(name: String = name): ConfigRef = {
+    new ConfigRef(name)
+  }
+  def withName(name: String): ConfigRef = {
+    copy(name = name)
+  }
+}
+object ConfigRef extends sbt.librarymanagement.ConfigRefFunctions {
+  
+  def apply(name: String): ConfigRef = new ConfigRef(name)
+}

--- a/librarymanagement/src/main/contraband-scala/sbt/librarymanagement/ConfigRef.scala
+++ b/librarymanagement/src/main/contraband-scala/sbt/librarymanagement/ConfigRef.scala
@@ -19,7 +19,7 @@ final class ConfigRef private (
     37 * (37 * (17 + "ConfigRef".##) + name.##)
   }
   override def toString: String = {
-    "ConfigRef(" + name + ")"
+    name
   }
   protected[this] def copy(name: String = name): ConfigRef = {
     new ConfigRef(name)

--- a/librarymanagement/src/main/contraband-scala/sbt/librarymanagement/ConfigRefFormats.scala
+++ b/librarymanagement/src/main/contraband-scala/sbt/librarymanagement/ConfigRefFormats.scala
@@ -1,0 +1,27 @@
+/**
+ * This code is generated using [[http://www.scala-sbt.org/contraband/ sbt-contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.librarymanagement
+import _root_.sjsonnew.{ Unbuilder, Builder, JsonFormat, deserializationError }
+trait ConfigRefFormats { self: sjsonnew.BasicJsonProtocol =>
+implicit lazy val ConfigRefFormat: JsonFormat[sbt.librarymanagement.ConfigRef] = new JsonFormat[sbt.librarymanagement.ConfigRef] {
+  override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): sbt.librarymanagement.ConfigRef = {
+    jsOpt match {
+      case Some(js) =>
+      unbuilder.beginObject(js)
+      val name = unbuilder.readField[String]("name")
+      unbuilder.endObject()
+      sbt.librarymanagement.ConfigRef(name)
+      case None =>
+      deserializationError("Expected JsObject but found None")
+    }
+  }
+  override def write[J](obj: sbt.librarymanagement.ConfigRef, builder: Builder[J]): Unit = {
+    builder.beginObject()
+    builder.addField("name", obj.name)
+    builder.endObject()
+  }
+}
+}

--- a/librarymanagement/src/main/contraband-scala/sbt/librarymanagement/ConfigurationReport.scala
+++ b/librarymanagement/src/main/contraband-scala/sbt/librarymanagement/ConfigurationReport.scala
@@ -7,7 +7,7 @@ package sbt.librarymanagement
 /** Provides information about resolution of a single configuration. */
 final class ConfigurationReport private (
   /** the configuration this report is for. */
-  val configuration: String,
+  val configuration: sbt.librarymanagement.ConfigRef,
   /** a sequence containing one report for each module resolved for this configuration. */
   val modules: Vector[sbt.librarymanagement.ModuleReport],
   /** a sequence containing one report for each org/name, which may or may not be part of the final resolution. */
@@ -27,10 +27,10 @@ final class ConfigurationReport private (
     (if (details.isEmpty) modules.mkString + details.flatMap(_.modules).filter(_.evicted).map("\t\t(EVICTED) " + _ + "\n").mkString
     else details.mkString)
   }
-  protected[this] def copy(configuration: String = configuration, modules: Vector[sbt.librarymanagement.ModuleReport] = modules, details: Vector[sbt.librarymanagement.OrganizationArtifactReport] = details): ConfigurationReport = {
+  protected[this] def copy(configuration: sbt.librarymanagement.ConfigRef = configuration, modules: Vector[sbt.librarymanagement.ModuleReport] = modules, details: Vector[sbt.librarymanagement.OrganizationArtifactReport] = details): ConfigurationReport = {
     new ConfigurationReport(configuration, modules, details)
   }
-  def withConfiguration(configuration: String): ConfigurationReport = {
+  def withConfiguration(configuration: sbt.librarymanagement.ConfigRef): ConfigurationReport = {
     copy(configuration = configuration)
   }
   def withModules(modules: Vector[sbt.librarymanagement.ModuleReport]): ConfigurationReport = {
@@ -42,5 +42,5 @@ final class ConfigurationReport private (
 }
 object ConfigurationReport {
   
-  def apply(configuration: String, modules: Vector[sbt.librarymanagement.ModuleReport], details: Vector[sbt.librarymanagement.OrganizationArtifactReport]): ConfigurationReport = new ConfigurationReport(configuration, modules, details)
+  def apply(configuration: sbt.librarymanagement.ConfigRef, modules: Vector[sbt.librarymanagement.ModuleReport], details: Vector[sbt.librarymanagement.OrganizationArtifactReport]): ConfigurationReport = new ConfigurationReport(configuration, modules, details)
 }

--- a/librarymanagement/src/main/contraband-scala/sbt/librarymanagement/ConfigurationReportFormats.scala
+++ b/librarymanagement/src/main/contraband-scala/sbt/librarymanagement/ConfigurationReportFormats.scala
@@ -5,13 +5,13 @@
 // DO NOT EDIT MANUALLY
 package sbt.librarymanagement
 import _root_.sjsonnew.{ Unbuilder, Builder, JsonFormat, deserializationError }
-trait ConfigurationReportFormats { self: sbt.librarymanagement.ModuleReportFormats with sbt.librarymanagement.OrganizationArtifactReportFormats with sjsonnew.BasicJsonProtocol =>
+trait ConfigurationReportFormats { self: sbt.librarymanagement.ConfigRefFormats with sbt.librarymanagement.ModuleReportFormats with sbt.librarymanagement.OrganizationArtifactReportFormats with sjsonnew.BasicJsonProtocol =>
 implicit lazy val ConfigurationReportFormat: JsonFormat[sbt.librarymanagement.ConfigurationReport] = new JsonFormat[sbt.librarymanagement.ConfigurationReport] {
   override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): sbt.librarymanagement.ConfigurationReport = {
     jsOpt match {
       case Some(js) =>
       unbuilder.beginObject(js)
-      val configuration = unbuilder.readField[String]("configuration")
+      val configuration = unbuilder.readField[sbt.librarymanagement.ConfigRef]("configuration")
       val modules = unbuilder.readField[Vector[sbt.librarymanagement.ModuleReport]]("modules")
       val details = unbuilder.readField[Vector[sbt.librarymanagement.OrganizationArtifactReport]]("details")
       unbuilder.endObject()

--- a/librarymanagement/src/main/contraband-scala/sbt/librarymanagement/InclExclRule.scala
+++ b/librarymanagement/src/main/contraband-scala/sbt/librarymanagement/InclExclRule.scala
@@ -17,7 +17,7 @@ final class InclExclRule private (
   val organization: String,
   val name: String,
   val artifact: String,
-  val configurations: Vector[String],
+  val configurations: Vector[sbt.librarymanagement.ConfigRef],
   val crossVersion: sbt.librarymanagement.CrossVersion) extends Serializable {
   
   private def this() = this("*", "*", "*", Vector.empty, sbt.librarymanagement.Disabled())
@@ -32,7 +32,7 @@ final class InclExclRule private (
   override def toString: String = {
     "InclExclRule(" + organization + ", " + name + ", " + artifact + ", " + configurations + ", " + crossVersion + ")"
   }
-  protected[this] def copy(organization: String = organization, name: String = name, artifact: String = artifact, configurations: Vector[String] = configurations, crossVersion: sbt.librarymanagement.CrossVersion = crossVersion): InclExclRule = {
+  protected[this] def copy(organization: String = organization, name: String = name, artifact: String = artifact, configurations: Vector[sbt.librarymanagement.ConfigRef] = configurations, crossVersion: sbt.librarymanagement.CrossVersion = crossVersion): InclExclRule = {
     new InclExclRule(organization, name, artifact, configurations, crossVersion)
   }
   def withOrganization(organization: String): InclExclRule = {
@@ -44,7 +44,7 @@ final class InclExclRule private (
   def withArtifact(artifact: String): InclExclRule = {
     copy(artifact = artifact)
   }
-  def withConfigurations(configurations: Vector[String]): InclExclRule = {
+  def withConfigurations(configurations: Vector[sbt.librarymanagement.ConfigRef]): InclExclRule = {
     copy(configurations = configurations)
   }
   def withCrossVersion(crossVersion: sbt.librarymanagement.CrossVersion): InclExclRule = {
@@ -54,5 +54,5 @@ final class InclExclRule private (
 object InclExclRule extends sbt.librarymanagement.InclExclRuleFunctions {
   
   def apply(): InclExclRule = new InclExclRule("*", "*", "*", Vector.empty, sbt.librarymanagement.Disabled())
-  def apply(organization: String, name: String, artifact: String, configurations: Vector[String], crossVersion: sbt.librarymanagement.CrossVersion): InclExclRule = new InclExclRule(organization, name, artifact, configurations, crossVersion)
+  def apply(organization: String, name: String, artifact: String, configurations: Vector[sbt.librarymanagement.ConfigRef], crossVersion: sbt.librarymanagement.CrossVersion): InclExclRule = new InclExclRule(organization, name, artifact, configurations, crossVersion)
 }

--- a/librarymanagement/src/main/contraband-scala/sbt/librarymanagement/InclExclRuleFormats.scala
+++ b/librarymanagement/src/main/contraband-scala/sbt/librarymanagement/InclExclRuleFormats.scala
@@ -5,7 +5,7 @@
 // DO NOT EDIT MANUALLY
 package sbt.librarymanagement
 import _root_.sjsonnew.{ Unbuilder, Builder, JsonFormat, deserializationError }
-trait InclExclRuleFormats { self: sbt.librarymanagement.CrossVersionFormats with sjsonnew.BasicJsonProtocol =>
+trait InclExclRuleFormats { self: sbt.librarymanagement.ConfigRefFormats with sbt.librarymanagement.CrossVersionFormats with sjsonnew.BasicJsonProtocol =>
 implicit lazy val InclExclRuleFormat: JsonFormat[sbt.librarymanagement.InclExclRule] = new JsonFormat[sbt.librarymanagement.InclExclRule] {
   override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): sbt.librarymanagement.InclExclRule = {
     jsOpt match {
@@ -14,7 +14,7 @@ implicit lazy val InclExclRuleFormat: JsonFormat[sbt.librarymanagement.InclExclR
       val organization = unbuilder.readField[String]("organization")
       val name = unbuilder.readField[String]("name")
       val artifact = unbuilder.readField[String]("artifact")
-      val configurations = unbuilder.readField[Vector[String]]("configurations")
+      val configurations = unbuilder.readField[Vector[sbt.librarymanagement.ConfigRef]]("configurations")
       val crossVersion = unbuilder.readField[sbt.librarymanagement.CrossVersion]("crossVersion")
       unbuilder.endObject()
       sbt.librarymanagement.InclExclRule(organization, name, artifact, configurations, crossVersion)

--- a/librarymanagement/src/main/contraband-scala/sbt/librarymanagement/LibraryManagementCodec.scala
+++ b/librarymanagement/src/main/contraband-scala/sbt/librarymanagement/LibraryManagementCodec.scala
@@ -5,7 +5,6 @@
 // DO NOT EDIT MANUALLY
 package sbt.librarymanagement
 trait LibraryManagementCodec extends sjsonnew.BasicJsonProtocol
-  with sbt.librarymanagement.ConfigurationFormats
   with sbt.librarymanagement.ChecksumFormats
   with sbt.librarymanagement.ArtifactFormats
   with sbt.librarymanagement.ArtifactTypeFilterFormats
@@ -24,6 +23,7 @@ trait LibraryManagementCodec extends sjsonnew.BasicJsonProtocol
   with sbt.librarymanagement.ConflictManagerFormats
   with sbt.librarymanagement.DeveloperFormats
   with sbt.librarymanagement.FileConfigurationFormats
+  with sbt.librarymanagement.ConfigurationFormats
   with sbt.librarymanagement.IvyScalaFormats
   with sbt.librarymanagement.ChainedResolverFormats
   with sbt.librarymanagement.MavenRepoFormats

--- a/librarymanagement/src/main/contraband-scala/sbt/librarymanagement/LibraryManagementCodec.scala
+++ b/librarymanagement/src/main/contraband-scala/sbt/librarymanagement/LibraryManagementCodec.scala
@@ -5,6 +5,7 @@
 // DO NOT EDIT MANUALLY
 package sbt.librarymanagement
 trait LibraryManagementCodec extends sjsonnew.BasicJsonProtocol
+  with sbt.librarymanagement.ConfigRefFormats
   with sbt.librarymanagement.ChecksumFormats
   with sbt.librarymanagement.ArtifactFormats
   with sbt.librarymanagement.ArtifactTypeFilterFormats

--- a/librarymanagement/src/main/contraband-scala/sbt/librarymanagement/ModuleReport.scala
+++ b/librarymanagement/src/main/contraband-scala/sbt/librarymanagement/ModuleReport.scala
@@ -24,7 +24,7 @@ final class ModuleReport private (
   val extraAttributes: Map[String, String],
   val isDefault: Option[Boolean],
   val branch: Option[String],
-  val configurations: Vector[String],
+  val configurations: Vector[sbt.librarymanagement.ConfigRef],
   val licenses: Vector[scala.Tuple2[String, Option[String]]],
   val callers: Vector[sbt.librarymanagement.Caller]) extends sbt.librarymanagement.ModuleReportExtra with Serializable {
   
@@ -41,7 +41,7 @@ final class ModuleReport private (
     s"\t\t$module: " +
     (if (arts.size <= 1) "" else "\n\t\t\t") + arts.mkString("\n\t\t\t") + "\n"
   }
-  protected[this] def copy(module: sbt.librarymanagement.ModuleID = module, artifacts: Vector[scala.Tuple2[sbt.librarymanagement.Artifact, java.io.File]] = artifacts, missingArtifacts: Vector[sbt.librarymanagement.Artifact] = missingArtifacts, status: Option[String] = status, publicationDate: Option[java.util.Calendar] = publicationDate, resolver: Option[String] = resolver, artifactResolver: Option[String] = artifactResolver, evicted: Boolean = evicted, evictedData: Option[String] = evictedData, evictedReason: Option[String] = evictedReason, problem: Option[String] = problem, homepage: Option[String] = homepage, extraAttributes: Map[String, String] = extraAttributes, isDefault: Option[Boolean] = isDefault, branch: Option[String] = branch, configurations: Vector[String] = configurations, licenses: Vector[scala.Tuple2[String, Option[String]]] = licenses, callers: Vector[sbt.librarymanagement.Caller] = callers): ModuleReport = {
+  protected[this] def copy(module: sbt.librarymanagement.ModuleID = module, artifacts: Vector[scala.Tuple2[sbt.librarymanagement.Artifact, java.io.File]] = artifacts, missingArtifacts: Vector[sbt.librarymanagement.Artifact] = missingArtifacts, status: Option[String] = status, publicationDate: Option[java.util.Calendar] = publicationDate, resolver: Option[String] = resolver, artifactResolver: Option[String] = artifactResolver, evicted: Boolean = evicted, evictedData: Option[String] = evictedData, evictedReason: Option[String] = evictedReason, problem: Option[String] = problem, homepage: Option[String] = homepage, extraAttributes: Map[String, String] = extraAttributes, isDefault: Option[Boolean] = isDefault, branch: Option[String] = branch, configurations: Vector[sbt.librarymanagement.ConfigRef] = configurations, licenses: Vector[scala.Tuple2[String, Option[String]]] = licenses, callers: Vector[sbt.librarymanagement.Caller] = callers): ModuleReport = {
     new ModuleReport(module, artifacts, missingArtifacts, status, publicationDate, resolver, artifactResolver, evicted, evictedData, evictedReason, problem, homepage, extraAttributes, isDefault, branch, configurations, licenses, callers)
   }
   def withModule(module: sbt.librarymanagement.ModuleID): ModuleReport = {
@@ -89,7 +89,7 @@ final class ModuleReport private (
   def withBranch(branch: Option[String]): ModuleReport = {
     copy(branch = branch)
   }
-  def withConfigurations(configurations: Vector[String]): ModuleReport = {
+  def withConfigurations(configurations: Vector[sbt.librarymanagement.ConfigRef]): ModuleReport = {
     copy(configurations = configurations)
   }
   def withLicenses(licenses: Vector[scala.Tuple2[String, Option[String]]]): ModuleReport = {
@@ -102,5 +102,5 @@ final class ModuleReport private (
 object ModuleReport {
   
   def apply(module: sbt.librarymanagement.ModuleID, artifacts: Vector[scala.Tuple2[sbt.librarymanagement.Artifact, java.io.File]], missingArtifacts: Vector[sbt.librarymanagement.Artifact]): ModuleReport = new ModuleReport(module, artifacts, missingArtifacts, None, None, None, None, false, None, None, None, None, Map.empty, None, None, Vector.empty, Vector.empty, Vector.empty)
-  def apply(module: sbt.librarymanagement.ModuleID, artifacts: Vector[scala.Tuple2[sbt.librarymanagement.Artifact, java.io.File]], missingArtifacts: Vector[sbt.librarymanagement.Artifact], status: Option[String], publicationDate: Option[java.util.Calendar], resolver: Option[String], artifactResolver: Option[String], evicted: Boolean, evictedData: Option[String], evictedReason: Option[String], problem: Option[String], homepage: Option[String], extraAttributes: Map[String, String], isDefault: Option[Boolean], branch: Option[String], configurations: Vector[String], licenses: Vector[scala.Tuple2[String, Option[String]]], callers: Vector[sbt.librarymanagement.Caller]): ModuleReport = new ModuleReport(module, artifacts, missingArtifacts, status, publicationDate, resolver, artifactResolver, evicted, evictedData, evictedReason, problem, homepage, extraAttributes, isDefault, branch, configurations, licenses, callers)
+  def apply(module: sbt.librarymanagement.ModuleID, artifacts: Vector[scala.Tuple2[sbt.librarymanagement.Artifact, java.io.File]], missingArtifacts: Vector[sbt.librarymanagement.Artifact], status: Option[String], publicationDate: Option[java.util.Calendar], resolver: Option[String], artifactResolver: Option[String], evicted: Boolean, evictedData: Option[String], evictedReason: Option[String], problem: Option[String], homepage: Option[String], extraAttributes: Map[String, String], isDefault: Option[Boolean], branch: Option[String], configurations: Vector[sbt.librarymanagement.ConfigRef], licenses: Vector[scala.Tuple2[String, Option[String]]], callers: Vector[sbt.librarymanagement.Caller]): ModuleReport = new ModuleReport(module, artifacts, missingArtifacts, status, publicationDate, resolver, artifactResolver, evicted, evictedData, evictedReason, problem, homepage, extraAttributes, isDefault, branch, configurations, licenses, callers)
 }

--- a/librarymanagement/src/main/contraband-scala/sbt/librarymanagement/ModuleReportFormats.scala
+++ b/librarymanagement/src/main/contraband-scala/sbt/librarymanagement/ModuleReportFormats.scala
@@ -5,7 +5,7 @@
 // DO NOT EDIT MANUALLY
 package sbt.librarymanagement
 import _root_.sjsonnew.{ Unbuilder, Builder, JsonFormat, deserializationError }
-trait ModuleReportFormats { self: sbt.librarymanagement.ModuleIDFormats with sbt.librarymanagement.ArtifactFormats with sbt.librarymanagement.CallerFormats with sjsonnew.BasicJsonProtocol =>
+trait ModuleReportFormats { self: sbt.librarymanagement.ModuleIDFormats with sbt.librarymanagement.ArtifactFormats with sbt.librarymanagement.ConfigRefFormats with sbt.librarymanagement.CallerFormats with sjsonnew.BasicJsonProtocol =>
 implicit lazy val ModuleReportFormat: JsonFormat[sbt.librarymanagement.ModuleReport] = new JsonFormat[sbt.librarymanagement.ModuleReport] {
   override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): sbt.librarymanagement.ModuleReport = {
     jsOpt match {
@@ -26,7 +26,7 @@ implicit lazy val ModuleReportFormat: JsonFormat[sbt.librarymanagement.ModuleRep
       val extraAttributes = unbuilder.readField[Map[String, String]]("extraAttributes")
       val isDefault = unbuilder.readField[Option[Boolean]]("isDefault")
       val branch = unbuilder.readField[Option[String]]("branch")
-      val configurations = unbuilder.readField[Vector[String]]("configurations")
+      val configurations = unbuilder.readField[Vector[sbt.librarymanagement.ConfigRef]]("configurations")
       val licenses = unbuilder.readField[Vector[scala.Tuple2[String, Option[String]]]]("licenses")
       val callers = unbuilder.readField[Vector[sbt.librarymanagement.Caller]]("callers")
       unbuilder.endObject()

--- a/librarymanagement/src/main/contraband-scala/sbt/librarymanagement/RetrieveConfigurationFormats.scala
+++ b/librarymanagement/src/main/contraband-scala/sbt/librarymanagement/RetrieveConfigurationFormats.scala
@@ -5,7 +5,7 @@
 // DO NOT EDIT MANUALLY
 package sbt.librarymanagement
 import _root_.sjsonnew.{ Unbuilder, Builder, JsonFormat, deserializationError }
-trait RetrieveConfigurationFormats { self: sbt.librarymanagement.ConfigurationFormats with sjsonnew.BasicJsonProtocol =>
+trait RetrieveConfigurationFormats { self: sbt.librarymanagement.ConfigRefFormats with sjsonnew.BasicJsonProtocol =>
 implicit lazy val RetrieveConfigurationFormat: JsonFormat[sbt.internal.librarymanagement.RetrieveConfiguration] = new JsonFormat[sbt.internal.librarymanagement.RetrieveConfiguration] {
   override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): sbt.internal.librarymanagement.RetrieveConfiguration = {
     jsOpt match {
@@ -14,7 +14,7 @@ implicit lazy val RetrieveConfigurationFormat: JsonFormat[sbt.internal.libraryma
       val retrieveDirectory = unbuilder.readField[java.io.File]("retrieveDirectory")
       val outputPattern = unbuilder.readField[String]("outputPattern")
       val sync = unbuilder.readField[Boolean]("sync")
-      val configurationsToRetrieve = unbuilder.readField[Option[Set[sbt.librarymanagement.Configuration]]]("configurationsToRetrieve")
+      val configurationsToRetrieve = unbuilder.readField[Option[Set[sbt.librarymanagement.ConfigRef]]]("configurationsToRetrieve")
       unbuilder.endObject()
       sbt.internal.librarymanagement.RetrieveConfiguration(retrieveDirectory, outputPattern, sync, configurationsToRetrieve)
       case None =>

--- a/librarymanagement/src/main/contraband/librarymanagement.json
+++ b/librarymanagement/src/main/contraband/librarymanagement.json
@@ -13,7 +13,7 @@
         { "name": "type",            "type": "String",                               "default": "Artifact.DefaultType",      "since": "0.0.1" },
         { "name": "extension",       "type": "String",                               "default": "Artifact.DefaultExtension", "since": "0.0.1" },
         { "name": "classifier",      "type": "Option[String]",                       "default": "None",                      "since": "0.0.1" },
-        { "name": "configurations",  "type": "sbt.librarymanagement.Configuration*", "default": "Vector.empty",              "since": "0.0.1" },
+        { "name": "configurations",  "type": "String*",                              "default": "Vector.empty",              "since": "0.0.1" },
         { "name": "url",             "type": "Option[java.net.URL]",                 "default": "None",                      "since": "0.0.1" },
         { "name": "extraAttributes", "type": "Map[String, String]",                  "default": "Map.empty",                 "since": "0.0.1" },
         { "name": "checksum",        "type": "Option[sbt.librarymanagement.Checksum]", "default": "None",                    "since": "0.0.1" }
@@ -60,22 +60,6 @@
         { "name": "isDirectlyForceDependency", "type": "boolean"                        }
       ],
       "toString": "s\"$caller\""
-    },
-    {
-      "name": "Configuration",
-      "namespace": "sbt.librarymanagement",
-      "target": "Scala",
-      "type": "record",
-      "doc": "Represents an Ivy configuration.",
-      "parents": "sbt.librarymanagement.ConfigurationExtra",
-      "fields": [
-        { "name": "name",           "type": "String"                                                                            },
-        { "name": "description",    "type": "String",                               "default": "\"\"",         "since": "0.0.1" },
-        { "name": "isPublic",       "type": "boolean",                              "default": "true",         "since": "0.0.1" },
-        { "name": "extendsConfigs", "type": "sbt.librarymanagement.Configuration*", "default": "Vector.empty", "since": "0.0.1" },
-        { "name": "transitive",     "type": "boolean",                              "default": "true",         "since": "0.0.1" }
-      ],
-      "toString": "name"
     },
     {
       "name": "ConfigurationReport",

--- a/librarymanagement/src/main/contraband/librarymanagement.json
+++ b/librarymanagement/src/main/contraband/librarymanagement.json
@@ -13,7 +13,7 @@
         { "name": "type",            "type": "String",                               "default": "Artifact.DefaultType",      "since": "0.0.1" },
         { "name": "extension",       "type": "String",                               "default": "Artifact.DefaultExtension", "since": "0.0.1" },
         { "name": "classifier",      "type": "Option[String]",                       "default": "None",                      "since": "0.0.1" },
-        { "name": "configurations",  "type": "String*",                              "default": "Vector.empty",              "since": "0.0.1" },
+        { "name": "configurations",  "type": "sbt.librarymanagement.ConfigRef*",     "default": "Vector.empty",              "since": "0.0.1" },
         { "name": "url",             "type": "Option[java.net.URL]",                 "default": "None",                      "since": "0.0.1" },
         { "name": "extraAttributes", "type": "Map[String, String]",                  "default": "Map.empty",                 "since": "0.0.1" },
         { "name": "checksum",        "type": "Option[sbt.librarymanagement.Checksum]", "default": "None",                    "since": "0.0.1" }
@@ -60,6 +60,23 @@
         { "name": "isDirectlyForceDependency", "type": "boolean"                        }
       ],
       "toString": "s\"$caller\""
+    },
+    {
+      "name": "ConfigRef",
+      "namespace": "sbt.librarymanagement",
+      "target": "Scala",
+      "type": "record",
+      "doc": [
+        "A reference to Configuration."
+      ],
+      "fields": [
+        {
+          "name": "name",
+          "type": "String",
+          "doc": [ "The name of the configuration that eventually get used by Maven." ]
+        }
+      ],
+      "parentsCompanion": "sbt.librarymanagement.ConfigRefFunctions"
     },
     {
       "name": "ConfigurationReport",

--- a/librarymanagement/src/main/contraband/librarymanagement.json
+++ b/librarymanagement/src/main/contraband/librarymanagement.json
@@ -52,7 +52,7 @@
       "type": "record",
       "fields": [
         { "name": "caller",                    "type": "sbt.librarymanagement.ModuleID" },
-        { "name": "callerConfigurations",      "type": "String*"                        },
+        { "name": "callerConfigurations",      "type": "sbt.librarymanagement.ConfigRef*" },
         { "name": "callerExtraAttributes",     "type": "Map[String, String]"            },
         { "name": "isForceDependency",         "type": "boolean"                        },
         { "name": "isChangingDependency",      "type": "boolean"                        },
@@ -76,7 +76,8 @@
           "doc": [ "The name of the configuration that eventually get used by Maven." ]
         }
       ],
-      "parentsCompanion": "sbt.librarymanagement.ConfigRefFunctions"
+      "parentsCompanion": "sbt.librarymanagement.ConfigRefFunctions",
+      "toString": "name"
     },
     {
       "name": "ConfigurationReport",
@@ -88,7 +89,7 @@
       ],
       "parents": "sbt.librarymanagement.ConfigurationReportExtra",
       "fields": [
-        { "name": "configuration", "type": "String", "doc": [ "the configuration this report is for." ] },
+        { "name": "configuration", "type": "sbt.librarymanagement.ConfigRef", "doc": [ "the configuration this report is for." ] },
         {
           "name": "modules",
           "type": "sbt.librarymanagement.ModuleReport*",
@@ -233,7 +234,7 @@
         { "name": "organization",   "type": "String",  "default": "\"*\"",        "since": "0.0.1" },
         { "name": "name",           "type": "String",  "default": "\"*\"",        "since": "0.0.1" },
         { "name": "artifact",       "type": "String",  "default": "\"*\"",        "since": "0.0.1" },
-        { "name": "configurations", "type": "String*", "default": "Vector.empty", "since": "0.0.1" },
+        { "name": "configurations", "type": "sbt.librarymanagement.ConfigRef*", "default": "Vector.empty", "since": "0.0.1" },
         { "name": "crossVersion",   "type": "sbt.librarymanagement.CrossVersion", "default": "sbt.librarymanagement.Disabled()", "since": "0.0.1"}
       ],
       "parentsCompanion": "sbt.librarymanagement.InclExclRuleFunctions"
@@ -351,7 +352,7 @@
         { "name": "extraAttributes",  "type": "Map[String, String]",                   "default": "Map.empty",    "since": "0.0.1" },
         { "name": "isDefault",        "type": "Option[Boolean]",                       "default": "None",         "since": "0.0.1" },
         { "name": "branch",           "type": "Option[String]",                        "default": "None",         "since": "0.0.1" },
-        { "name": "configurations",   "type": "String*",                               "default": "Vector.empty", "since": "0.0.1" },
+        { "name": "configurations",   "type": "sbt.librarymanagement.ConfigRef*",                               "default": "Vector.empty", "since": "0.0.1" },
         { "name": "licenses",         "type": "scala.Tuple2[String, Option[String]]*", "default": "Vector.empty", "since": "0.0.1" },
         { "name": "callers",          "type": "sbt.librarymanagement.Caller*",         "default": "Vector.empty", "since": "0.0.1" }
       ],
@@ -805,8 +806,8 @@
       "fields": [
         { "name": "retrieveDirectory",        "type": "java.io.File"                                                                           },
         { "name": "outputPattern",            "type": "String"                                                                                 },
-        { "name": "sync",                     "type": "boolean",                                          "default": "false", "since": "0.0.1" },
-        { "name": "configurationsToRetrieve", "type": "Option[Set[sbt.librarymanagement.Configuration]]", "default": "None",  "since": "0.0.1" }
+        { "name": "sync",                     "type": "boolean",                                      "default": "false", "since": "0.0.1" },
+        { "name": "configurationsToRetrieve", "type": "Option[Set[sbt.librarymanagement.ConfigRef]]", "default": "None",  "since": "0.0.1" }
       ]
     },
     {

--- a/librarymanagement/src/main/scala/sbt/internal/librarymanagement/Ivy.scala
+++ b/librarymanagement/src/main/scala/sbt/internal/librarymanagement/Ivy.scala
@@ -238,9 +238,9 @@ final class IvySbt(val configuration: IvyConfiguration) { self =>
       import ic._
       val moduleID = newConfiguredModuleID(module, moduleInfo, configurations)
       IvySbt.setConflictManager(moduleID, conflictManager, ivy.getSettings)
-      val defaultConf = defaultConfiguration getOrElse Configurations.config(
-        ModuleDescriptor.DEFAULT_CONFIGURATION
-      )
+      val defaultConf = defaultConfiguration getOrElse Configuration(
+        "Default",
+        ModuleDescriptor.DEFAULT_CONFIGURATION)
       log.debug(
         "Using inline dependencies specified in Scala" + (if (ivyXML.isEmpty) "."
                                                           else " and XML.")
@@ -859,7 +859,7 @@ private[sbt] object IvySbt {
   ): Unit = {
     val confs =
       if (artifact.configurations.isEmpty) allConfigurations
-      else artifact.configurations.map(_.name)
+      else artifact.configurations
     confs foreach addConfiguration
   }
 

--- a/librarymanagement/src/main/scala/sbt/internal/librarymanagement/Ivy.scala
+++ b/librarymanagement/src/main/scala/sbt/internal/librarymanagement/Ivy.scala
@@ -829,7 +829,7 @@ private[sbt] object IvySbt {
           IvyScala.excludeRule(
             excls.organization,
             excls.name,
-            excls.configurations,
+            excls.configurations map { _.name },
             excls.artifact
           )
         )
@@ -842,7 +842,7 @@ private[sbt] object IvySbt {
           IvyScala.includeRule(
             incls.organization,
             incls.name,
-            incls.configurations,
+            incls.configurations map { _.name },
             incls.artifact
           )
         )
@@ -877,7 +877,7 @@ private[sbt] object IvySbt {
     val exclude = CrossVersion.substituteCross(exclude0, ivyScala)
     val confs =
       if (exclude.configurations.isEmpty) moduleID.getConfigurationsNames.toList
-      else exclude.configurations
+      else exclude.configurations map { _.name }
     val excludeRule =
       IvyScala.excludeRule(exclude.organization, exclude.name, confs, exclude.artifact)
     moduleID.addExcludeRule(excludeRule)

--- a/librarymanagement/src/main/scala/sbt/internal/librarymanagement/IvyRetrieve.scala
+++ b/librarymanagement/src/main/scala/sbt/internal/librarymanagement/IvyRetrieve.scala
@@ -217,7 +217,7 @@ object IvyRetrieve {
       getType,
       getExt,
       Option(getExtraAttribute("classifier")),
-      getConfigurations.toVector map Configurations.config,
+      getConfigurations.toVector,
       Option(getUrl)
     )
   }

--- a/librarymanagement/src/main/scala/sbt/internal/librarymanagement/IvyRetrieve.scala
+++ b/librarymanagement/src/main/scala/sbt/internal/librarymanagement/IvyRetrieve.scala
@@ -89,7 +89,7 @@ object IvyRetrieve {
     def toCaller(caller: IvyCaller): Caller = {
       val m = toModuleID(caller.getModuleRevisionId)
       val callerConfigurations = caller.getCallerConfigurations.toVector collect {
-        case x if nonEmptyString(x).isDefined => x
+        case x if nonEmptyString(x).isDefined => ConfigRef(x)
       }
       val ddOpt = Option(caller.getDependencyDescriptor)
       val (extraAttributes, isForce, isChanging, isTransitive, isDirectlyForce) = ddOpt match {
@@ -167,7 +167,9 @@ object IvyRetrieve {
       case _        => dep.getResolvedId.getExtraAttributes
     })
     val isDefault = Option(dep.getDescriptor) map { _.isDefault }
-    val configurations = dep.getConfigurations(confReport.getConfiguration).toVector
+    val configurations = dep.getConfigurations(confReport.getConfiguration).toVector map {
+      ConfigRef(_)
+    }
     val licenses: Vector[(String, Option[String])] = mdOpt match {
       case Some(md) =>
         md.getLicenses.toVector collect {
@@ -235,7 +237,7 @@ object IvyRetrieve {
     UpdateStats(report.getResolveTime, report.getDownloadTime, report.getDownloadSize, false)
   def configurationReport(confReport: ConfigurationResolveReport): ConfigurationReport =
     ConfigurationReport(
-      confReport.getConfiguration,
+      ConfigRef(confReport.getConfiguration),
       moduleReports(confReport),
       organizationArtifactReports(confReport)
     )

--- a/librarymanagement/src/main/scala/sbt/internal/librarymanagement/IvyRetrieve.scala
+++ b/librarymanagement/src/main/scala/sbt/internal/librarymanagement/IvyRetrieve.scala
@@ -217,7 +217,9 @@ object IvyRetrieve {
       getType,
       getExt,
       Option(getExtraAttribute("classifier")),
-      getConfigurations.toVector,
+      getConfigurations.toVector map { c: String =>
+        ConfigRef(c)
+      },
       Option(getUrl)
     )
   }

--- a/librarymanagement/src/main/scala/sbt/internal/librarymanagement/JsonUtil.scala
+++ b/librarymanagement/src/main/scala/sbt/internal/librarymanagement/JsonUtil.scala
@@ -35,7 +35,7 @@ private[sbt] object JsonUtil {
   def toLite(ur: UpdateReport): UpdateReportLite =
     UpdateReportLite(ur.configurations map { cr =>
       ConfigurationReportLite(
-        cr.configuration,
+        cr.configuration.name,
         cr.details map {
           oar =>
             OrganizationArtifactReport(
@@ -92,7 +92,7 @@ private[sbt] object JsonUtil {
           !mr.evicted && mr.problem.isEmpty
         }
       }
-      ConfigurationReport(cr.configuration, modules, details)
+      ConfigurationReport(ConfigRef(cr.configuration), modules, details)
     }
     UpdateReport(cachedDescriptor, configReports, stats, Map.empty)
   }

--- a/librarymanagement/src/main/scala/sbt/librarymanagement/ArtifactExtra.scala
+++ b/librarymanagement/src/main/scala/sbt/librarymanagement/ArtifactExtra.scala
@@ -11,7 +11,7 @@ abstract class ArtifactExtra {
   def `type`: String
   def extension: String
   def classifier: Option[String]
-  def configurations: Vector[Configuration]
+  def configurations: Vector[String]
   def url: Option[URL]
   def extraAttributes: Map[String, String]
   def checksum: Option[Checksum]
@@ -21,7 +21,7 @@ abstract class ArtifactExtra {
       `type`: String = `type`,
       extension: String = extension,
       classifier: Option[String] = classifier,
-      configurations: Vector[Configuration] = configurations,
+      configurations: Vector[String] = configurations,
       url: Option[URL] = url,
       extraAttributes: Map[String, String] = extraAttributes,
       checksum: Option[Checksum] = checksum
@@ -58,7 +58,7 @@ abstract class ArtifactFunctions {
       `type`: String,
       extension: String,
       classifier: Option[String],
-      configurations: Vector[Configuration],
+      configurations: Vector[String],
       url: Option[URL]
   ): Artifact = Artifact(name, `type`, extension, classifier, configurations, url, empty, None)
 
@@ -67,7 +67,7 @@ abstract class ArtifactFunctions {
 
   def sources(name: String) = classified(name, SourceClassifier)
   def javadoc(name: String) = classified(name, DocClassifier)
-  def pom(name: String) = Artifact(name, PomType, PomType, None, Vector(Pom), None)
+  def pom(name: String) = Artifact(name, PomType, PomType, None, Vector(Pom.name), None)
 
   // Possible ivy artifact types such that sbt will treat those artifacts at sources / docs
   val DefaultSourceTypes = Set("src", "source", "sources")

--- a/librarymanagement/src/main/scala/sbt/librarymanagement/ArtifactExtra.scala
+++ b/librarymanagement/src/main/scala/sbt/librarymanagement/ArtifactExtra.scala
@@ -11,7 +11,7 @@ abstract class ArtifactExtra {
   def `type`: String
   def extension: String
   def classifier: Option[String]
-  def configurations: Vector[String]
+  def configurations: Vector[ConfigRef]
   def url: Option[URL]
   def extraAttributes: Map[String, String]
   def checksum: Option[Checksum]
@@ -21,7 +21,7 @@ abstract class ArtifactExtra {
       `type`: String = `type`,
       extension: String = extension,
       classifier: Option[String] = classifier,
-      configurations: Vector[String] = configurations,
+      configurations: Vector[ConfigRef] = configurations,
       url: Option[URL] = url,
       extraAttributes: Map[String, String] = extraAttributes,
       checksum: Option[Checksum] = checksum
@@ -58,7 +58,7 @@ abstract class ArtifactFunctions {
       `type`: String,
       extension: String,
       classifier: Option[String],
-      configurations: Vector[String],
+      configurations: Vector[ConfigRef],
       url: Option[URL]
   ): Artifact = Artifact(name, `type`, extension, classifier, configurations, url, empty, None)
 
@@ -67,7 +67,7 @@ abstract class ArtifactFunctions {
 
   def sources(name: String) = classified(name, SourceClassifier)
   def javadoc(name: String) = classified(name, DocClassifier)
-  def pom(name: String) = Artifact(name, PomType, PomType, None, Vector(Pom.name), None)
+  def pom(name: String) = Artifact(name, PomType, PomType, None, Vector(Pom), None)
 
   // Possible ivy artifact types such that sbt will treat those artifacts at sources / docs
   val DefaultSourceTypes = Set("src", "source", "sources")

--- a/librarymanagement/src/main/scala/sbt/librarymanagement/Configuration.scala
+++ b/librarymanagement/src/main/scala/sbt/librarymanagement/Configuration.scala
@@ -63,6 +63,8 @@ final class Configuration private[sbt] (
   def withTransitive(transitive: Boolean): Configuration = {
     copy(transitive = transitive)
   }
+
+  def toConfigRef: ConfigRef = ConfigRef(name)
 }
 object Configuration {
   private[sbt] def apply(id: String, name: String): Configuration =

--- a/librarymanagement/src/main/scala/sbt/librarymanagement/Configuration.scala
+++ b/librarymanagement/src/main/scala/sbt/librarymanagement/Configuration.scala
@@ -1,0 +1,77 @@
+package sbt
+package librarymanagement
+
+/** Represents an Ivy configuration. */
+final class Configuration private[sbt] (
+    val id: String,
+    val name: String,
+    val description: String,
+    val isPublic: Boolean,
+    val extendsConfigs: Vector[sbt.librarymanagement.Configuration],
+    val transitive: Boolean)
+    extends sbt.librarymanagement.ConfigurationExtra
+    with Serializable {
+
+  require(name != null, "name cannot be null")
+  require(name.size > 0, "name cannot be empty")
+  require(id != null, "id cannot be null")
+  require(id.size > 0, "id cannot be empty")
+  require(id.head.isUpper, s"id must be capitalized: $id")
+
+  private def this(id: String, name: String) =
+    this(id, name, "", true, Vector.empty, true)
+
+  override def equals(o: Any): Boolean = o match {
+    case x: Configuration =>
+      (this.id == x.id) &&
+        (this.name == x.name) &&
+        (this.description == x.description) &&
+        (this.isPublic == x.isPublic) &&
+        (this.extendsConfigs == x.extendsConfigs) &&
+        (this.transitive == x.transitive)
+    case _ => false
+  }
+  override def hashCode: Int = {
+    37 * (37 * (37 * (37 * (37 * (37 * (17 + id.##) + name.##) + description.##) + isPublic.##) + extendsConfigs.##) + transitive.##)
+  }
+  override def toString: String = {
+    name
+  }
+  protected[this] def copy(id: String = id,
+                           name: String = name,
+                           description: String = description,
+                           isPublic: Boolean = isPublic,
+                           extendsConfigs: Vector[sbt.librarymanagement.Configuration] =
+                             extendsConfigs,
+                           transitive: Boolean = transitive): Configuration = {
+    new Configuration(id, name, description, isPublic, extendsConfigs, transitive)
+  }
+
+  def withDescription(description: String): Configuration = {
+    copy(description = description)
+  }
+
+  def withIsPublic(isPublic: Boolean): Configuration = {
+    copy(isPublic = isPublic)
+  }
+
+  def withExtendsConfigs(
+      extendsConfigs: Vector[sbt.librarymanagement.Configuration]): Configuration = {
+    copy(extendsConfigs = extendsConfigs)
+  }
+
+  def withTransitive(transitive: Boolean): Configuration = {
+    copy(transitive = transitive)
+  }
+}
+object Configuration {
+  private[sbt] def apply(id: String, name: String): Configuration =
+    new Configuration(id, name, "", true, Vector.empty, true)
+  private[sbt] def apply(id: String,
+                         name: String,
+                         description: String,
+                         isPublic: Boolean,
+                         extendsConfigs: Vector[sbt.librarymanagement.Configuration],
+                         transitive: Boolean): Configuration =
+    new Configuration(id, name, description, isPublic, extendsConfigs, transitive)
+}

--- a/librarymanagement/src/main/scala/sbt/librarymanagement/ConfigurationExtra.scala
+++ b/librarymanagement/src/main/scala/sbt/librarymanagement/ConfigurationExtra.scala
@@ -134,3 +134,8 @@ private[sbt] object ConfigurationMacro {
       .enclosingContextChain
       .map(_.tree.asInstanceOf[c.Tree])
 }
+
+abstract class ConfigRefFunctions {
+  implicit def configToConfigRef(c: Configuration): ConfigRef =
+    c.toConfigRef
+}

--- a/librarymanagement/src/main/scala/sbt/librarymanagement/ConfigurationExtra.scala
+++ b/librarymanagement/src/main/scala/sbt/librarymanagement/ConfigurationExtra.scala
@@ -14,6 +14,7 @@ object Configurations {
   def defaultInternal: Seq[Configuration] = Seq(CompileInternal, RuntimeInternal, TestInternal)
   def auxiliary: Seq[Configuration] = Seq(Pom)
   def names(cs: Seq[Configuration]) = cs.map(_.name)
+  def refs(cs: Seq[Configuration]) = cs.map(_.toConfigRef)
 
   lazy val RuntimeInternal = optionalInternal(Runtime)
   lazy val TestInternal = fullInternal(Test)

--- a/librarymanagement/src/main/scala/sbt/librarymanagement/ConfigurationFormats.scala
+++ b/librarymanagement/src/main/scala/sbt/librarymanagement/ConfigurationFormats.scala
@@ -1,0 +1,46 @@
+/**
+ * This code is generated using [[http://www.scala-sbt.org/contraband/ sbt-contraband]].
+ */
+package sbt
+package librarymanagement
+
+import _root_.sjsonnew.{ deserializationError, serializationError, Builder, JsonFormat, Unbuilder }
+trait ConfigurationFormats {
+  self: sbt.librarymanagement.ConfigurationFormats with sjsonnew.BasicJsonProtocol =>
+  implicit lazy val ConfigurationFormat: JsonFormat[sbt.librarymanagement.Configuration] =
+    new JsonFormat[sbt.librarymanagement.Configuration] {
+      override def read[J](jsOpt: Option[J],
+                           unbuilder: Unbuilder[J]): sbt.librarymanagement.Configuration = {
+        jsOpt match {
+          case Some(js) =>
+            unbuilder.beginObject(js)
+            val id = unbuilder.readField[String]("id")
+            val name = unbuilder.readField[String]("name")
+            val description = unbuilder.readField[String]("description")
+            val isPublic = unbuilder.readField[Boolean]("isPublic")
+            val extendsConfigs =
+              unbuilder.readField[Vector[sbt.librarymanagement.Configuration]]("extendsConfigs")
+            val transitive = unbuilder.readField[Boolean]("transitive")
+            unbuilder.endObject()
+            new sbt.librarymanagement.Configuration(id,
+                                                    name,
+                                                    description,
+                                                    isPublic,
+                                                    extendsConfigs,
+                                                    transitive)
+          case None =>
+            deserializationError("Expected JsObject but found None")
+        }
+      }
+      override def write[J](obj: sbt.librarymanagement.Configuration, builder: Builder[J]): Unit = {
+        builder.beginObject()
+        builder.addField("id", obj.id)
+        builder.addField("name", obj.name)
+        builder.addField("description", obj.description)
+        builder.addField("isPublic", obj.isPublic)
+        builder.addField("extendsConfigs", obj.extendsConfigs)
+        builder.addField("transitive", obj.transitive)
+        builder.endObject()
+      }
+    }
+}

--- a/librarymanagement/src/main/scala/sbt/librarymanagement/EvictionWarning.scala
+++ b/librarymanagement/src/main/scala/sbt/librarymanagement/EvictionWarning.scala
@@ -8,7 +8,7 @@ import sbt.util.ShowLines
 import sbt.internal.librarymanagement.{ InlineConfiguration, IvySbt }
 
 final class EvictionWarningOptions private[sbt] (
-    val configurations: Seq[Configuration],
+    val configurations: Seq[ConfigRef],
     val warnScalaVersionEviction: Boolean,
     val warnDirectEvictions: Boolean,
     val warnTransitiveEvictions: Boolean,
@@ -16,9 +16,7 @@ final class EvictionWarningOptions private[sbt] (
     val showCallers: Boolean,
     val guessCompatible: Function1[(ModuleID, Option[ModuleID], Option[IvyScala]), Boolean]
 ) {
-  private[sbt] def configStrings = configurations map { _.name }
-
-  def withConfigurations(configurations: Seq[Configuration]): EvictionWarningOptions =
+  def withConfigurations(configurations: Seq[ConfigRef]): EvictionWarningOptions =
     copy(configurations = configurations)
   def withWarnScalaVersionEviction(warnScalaVersionEviction: Boolean): EvictionWarningOptions =
     copy(warnScalaVersionEviction = warnScalaVersionEviction)
@@ -36,7 +34,7 @@ final class EvictionWarningOptions private[sbt] (
     copy(guessCompatible = guessCompatible)
 
   private[sbt] def copy(
-      configurations: Seq[Configuration] = configurations,
+      configurations: Seq[ConfigRef] = configurations,
       warnScalaVersionEviction: Boolean = warnScalaVersionEviction,
       warnDirectEvictions: Boolean = warnDirectEvictions,
       warnTransitiveEvictions: Boolean = warnTransitiveEvictions,
@@ -193,7 +191,7 @@ object EvictionWarning {
   ): Seq[OrganizationArtifactReport] = {
     val buffer: mutable.ListBuffer[OrganizationArtifactReport] = mutable.ListBuffer()
     val confs = report.configurations filter { x =>
-      options.configStrings contains x.configuration
+      options.configurations contains x.configuration
     }
     confs flatMap { confReport =>
       confReport.details map { detail =>

--- a/librarymanagement/src/main/scala/sbt/librarymanagement/RichUpdateReport.scala
+++ b/librarymanagement/src/main/scala/sbt/librarymanagement/RichUpdateReport.scala
@@ -69,7 +69,7 @@ final class RichUpdateReport(report: UpdateReport) {
     }
 
   private[sbt] def substitute(
-      f: (String, ModuleID, Vector[(Artifact, File)]) => Vector[(Artifact, File)]
+      f: (ConfigRef, ModuleID, Vector[(Artifact, File)]) => Vector[(Artifact, File)]
   ): UpdateReport =
     moduleReportMap { (configuration, modReport) =>
       val newArtifacts = f(configuration, modReport.module, modReport.artifacts)
@@ -78,15 +78,15 @@ final class RichUpdateReport(report: UpdateReport) {
         .withMissingArtifacts(modReport.missingArtifacts)
     }
 
-  def toSeq: Seq[(String, ModuleID, Artifact, File)] = toVector
-  def toVector: Vector[(String, ModuleID, Artifact, File)] =
+  def toSeq: Seq[(ConfigRef, ModuleID, Artifact, File)] = toVector
+  def toVector: Vector[(ConfigRef, ModuleID, Artifact, File)] =
     for {
       confReport <- report.configurations
       modReport <- confReport.modules
       (artifact, file) <- modReport.artifacts
     } yield (confReport.configuration, modReport.module, artifact, file)
 
-  def allMissing: Vector[(String, ModuleID, Artifact)] =
+  def allMissing: Vector[(ConfigRef, ModuleID, Artifact)] =
     for {
       confReport <- report.configurations
       modReport <- confReport.modules
@@ -99,7 +99,7 @@ final class RichUpdateReport(report: UpdateReport) {
         .withMissingArtifacts((modReport.missingArtifacts ++ f(modReport.module)).distinct)
     }
 
-  private[sbt] def moduleReportMap(f: (String, ModuleReport) => ModuleReport): UpdateReport = {
+  private[sbt] def moduleReportMap(f: (ConfigRef, ModuleReport) => ModuleReport): UpdateReport = {
     val newConfigurations = report.configurations.map { confReport =>
       import confReport._
       val newModules = modules map { modReport =>

--- a/librarymanagement/src/main/scala/sbt/librarymanagement/UpdateReportExtra.scala
+++ b/librarymanagement/src/main/scala/sbt/librarymanagement/UpdateReportExtra.scala
@@ -7,7 +7,7 @@ import java.io.File
 import java.{ util => ju }
 
 abstract class ConfigurationReportExtra {
-  def configuration: String
+  def configuration: ConfigRef
   def modules: Vector[ModuleReport]
   def details: Vector[OrganizationArtifactReport]
 
@@ -28,7 +28,7 @@ abstract class ConfigurationReportExtra {
     } else module
   }
 
-  def retrieve(f: (String, ModuleID, Artifact, File) => File): ConfigurationReport =
+  def retrieve(f: (ConfigRef, ModuleID, Artifact, File) => File): ConfigurationReport =
     ConfigurationReport(configuration, modules map {
       _.retrieve((mid, art, file) => f(configuration, mid, art, file))
     }, details)
@@ -50,7 +50,7 @@ abstract class ModuleReportExtra {
   def extraAttributes: Map[String, String]
   def isDefault: Option[Boolean]
   def branch: Option[String]
-  def configurations: Vector[String]
+  def configurations: Vector[ConfigRef]
   def licenses: Vector[(String, Option[String])]
   def callers: Vector[Caller]
 
@@ -115,7 +115,7 @@ abstract class ModuleReportExtra {
       extraAttributes: Map[String, String] = extraAttributes,
       isDefault: Option[Boolean] = isDefault,
       branch: Option[String] = branch,
-      configurations: Vector[String] = configurations,
+      configurations: Vector[ConfigRef] = configurations,
       licenses: Vector[(String, Option[String])] = licenses,
       callers: Vector[Caller] = callers
   ): ModuleReport
@@ -144,12 +144,12 @@ abstract class UpdateReportExtra {
     }
   }
 
-  def retrieve(f: (String, ModuleID, Artifact, File) => File): UpdateReport =
+  def retrieve(f: (ConfigRef, ModuleID, Artifact, File) => File): UpdateReport =
     UpdateReport(cachedDescriptor, configurations map { _ retrieve f }, stats, stamps)
 
   /** Gets the report for the given configuration, or `None` if the configuration was not resolved.*/
-  def configuration(s: String) = configurations.find(_.configuration == s)
+  def configuration(s: ConfigRef) = configurations.find(_.configuration == s)
 
   /** Gets the names of all resolved configurations.  This `UpdateReport` contains one `ConfigurationReport` for each configuration in this list. */
-  def allConfigurations: Seq[String] = configurations.map(_.configuration)
+  def allConfigurations: Vector[ConfigRef] = configurations.map(_.configuration)
 }

--- a/librarymanagement/src/test/scala/ConfigMacroSpec.scala
+++ b/librarymanagement/src/test/scala/ConfigMacroSpec.scala
@@ -1,0 +1,61 @@
+package sbt.internal.librarymanagement
+
+import sbt.librarymanagement.Configuration
+import sbt.librarymanagement.Configurations.config
+import scala.util.control.NonFatal
+import org.scalacheck._
+import Prop._
+
+class ConfigDefs {
+  lazy val Kompile = config("kompile")
+  val X = config("x")
+  val Z = config("z").hide
+  val A: Configuration = config("a")
+  lazy val Aa: Configuration = config("aa")
+}
+
+object ConfigMacroSpec extends Properties("ConfigMacroSpec") {
+  lazy val cd = new ConfigDefs
+  import cd._
+
+  def secure(f: => Prop): Prop =
+    try {
+      Prop.secure(f)
+    } catch {
+      case NonFatal(e) =>
+        e.printStackTrace
+        throw e
+    }
+
+  property("Explicit type on lazy val supported") = secure {
+    check(Aa, "Aa", "aa", true)
+  }
+
+  property("Explicit type on val supported") = secure {
+    check(A, "A", "a", true)
+  }
+
+  property("lazy vals supported") = secure {
+    check(Kompile, "Kompile", "kompile", true)
+  }
+
+  property("plain vals supported") = secure {
+    check(X, "X", "x", true)
+  }
+
+  property("Directory overridable") = secure {
+    check(Z, "Z", "z", false)
+  }
+
+  def check(c: Configuration, id: String, name: String, isPublic: Boolean): Prop = {
+    s"Expected id: $id" |:
+      s"Expected name: $name" |:
+      s"Expected isPublic: $isPublic" |:
+      s"Actual id: ${c.id}" |:
+      s"Actual name: ${c.name}" |:
+      s"Actual isPublic: ${c.isPublic}" |:
+      (c.id == id) &&
+    (c.name == name) &&
+    (c.isPublic == isPublic)
+  }
+}

--- a/librarymanagement/src/test/scala/DMSerializationSpec.scala
+++ b/librarymanagement/src/test/scala/DMSerializationSpec.scala
@@ -57,7 +57,7 @@ class DMSerializationSpec extends UnitSpec {
                  UpdateStats(0, 0, 0, false),
                  Map(new File("./foo") -> 0))
   lazy val configurationReportExample =
-    ConfigurationReport("compile",
+    ConfigurationReport(ConfigRef("compile"),
                         Vector(moduleReportExample),
                         Vector(organizationArtifactReportExample))
   lazy val organizationArtifactReportExample =

--- a/librarymanagement/src/test/scala/sbt/internal/librarymanagement/IvyRepoSpec.scala
+++ b/librarymanagement/src/test/scala/sbt/internal/librarymanagement/IvyRepoSpec.scala
@@ -28,7 +28,7 @@ class IvyRepoSpec extends BaseIvySpecification with DependencyBuilders {
     val report = ivyUpdate(m)
 
     import Inside._
-    inside(report.configuration("compile").map(_.modules)) {
+    inside(report.configuration(ConfigRef("compile")).map(_.modules)) {
       case Some(Seq(mr)) =>
         inside(mr.artifacts) {
           case Seq((ar, _)) =>
@@ -82,7 +82,7 @@ class IvyRepoSpec extends BaseIvySpecification with DependencyBuilders {
                                                log)
 
     import Inside._
-    inside(report2.configuration("compile").map(_.modules)) {
+    inside(report2.configuration(ConfigRef("compile")).map(_.modules)) {
       case Some(Seq(mr)) =>
         inside(mr.artifacts) {
           case Seq((ar, _)) =>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -46,6 +46,7 @@ object Dependencies {
   val scalaCompiler = Def.setting { "org.scala-lang" % "scala-compiler" % scalaVersion.value }
   val scalaXml = scala211Module("scala-xml", "1.0.5")
   val scalaTest = "org.scalatest" %% "scalatest" % "3.0.1" % Test
+  val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.13.4" % Test
   val sjsonnew = Def.setting { "com.eed3si9n" %% "sjson-new-core" % contrabandSjsonNewVersion.value }
   val sjsonnewScalaJson = Def.setting { "com.eed3si9n" %% "sjson-new-scalajson" % contrabandSjsonNewVersion.value }
   val gigahorseOkhttp = "com.eed3si9n" %% "gigahorse-okhttp" % "0.3.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -43,6 +43,7 @@ object Dependencies {
   val ivy = "org.scala-sbt.ivy" % "ivy" % "2.3.0-sbt-a3314352b638afbf0dca19f127e8263ed6f898bd"
   val jsch = "com.jcraft" % "jsch" % "0.1.46" intransitive ()
   val scalaReflect = Def.setting { "org.scala-lang" % "scala-reflect" % scalaVersion.value }
+  val scalaCompiler = Def.setting { "org.scala-lang" % "scala-compiler" % scalaVersion.value }
   val scalaXml = scala211Module("scala-xml", "1.0.5")
   val scalaTest = "org.scalatest" %% "scalatest" % "3.0.1" % Test
   val sjsonnew = Def.setting { "com.eed3si9n" %% "sjson-new-core" % contrabandSjsonNewVersion.value }


### PR DESCRIPTION
In preparation to forward porting https://github.com/sbt/sbt/pull/3255, this changes the implementation of `def config(name: String)` so it captures the LHS as the `id` field in Configuration.
The constructor now enforces that the `id` (the Scala identifier for val) starts with upper case, like `Compile` and `Test`.

```scala
lazy val Compile = config("compie")
```

https://github.com/sbt/sbt/issues/2890