### PR TITLE
Add constant CrossVersion

### DIFF
--- a/librarymanagement/src/main/contraband/librarymanagement.json
+++ b/librarymanagement/src/main/contraband/librarymanagement.json
@@ -151,6 +151,18 @@
           ]
         },
         {
+          "name": "Constant",
+          "namespace": "sbt.librarymanagement",
+          "target": "Scala",
+          "doc": [
+            "Cross-versions a module using the string `value`."
+          ],
+          "type": "record",
+          "fields": [
+            { "name": "value", "type": "String", "default": "\"\"", "since": "0.0.2" }
+          ]
+        },
+        {
           "name": "Patch",
           "namespace": "sbt.librarymanagement",
           "target": "Scala",

--- a/librarymanagement/src/main/scala/sbt/librarymanagement/CrossVersionExtra.scala
+++ b/librarymanagement/src/main/scala/sbt/librarymanagement/CrossVersionExtra.scala
@@ -24,6 +24,9 @@ abstract class CrossVersionFunctions {
   /** Cross-versions a module with the binary version (typically the binary Scala version).  */
   def binary: CrossVersion = Binary()
 
+  /** Cross-versions a module with a constant string (typically the binary Scala version).  */
+  def constant(value: String): CrossVersion = Constant(value)
+
   /**
    * Cross-versions a module with the result of prepending `prefix` and appending `suffix` to the binary version
    * (typically the binary Scala version).  See also [[sbt.librarymanagement.Binary]].
@@ -58,6 +61,7 @@ abstract class CrossVersionFunctions {
     cross match {
       case _: Disabled => None
       case b: Binary   => append(b.prefix + binaryVersion + b.suffix)
+      case c: Constant => append(c.value)
       case _: Patch    => append(patchFun(fullVersion))
       case f: Full     => append(f.prefix + fullVersion + f.suffix)
     }

--- a/librarymanagement/src/test/scala/CrossVersionTest.scala
+++ b/librarymanagement/src/test/scala/CrossVersionTest.scala
@@ -230,6 +230,13 @@ class CrossVersionTest extends UnitSpec {
     patchVersion("2.11.8-RC1-bin-extra") shouldBe Some("artefact_2.11.8-RC1")
   }
 
+  private def constantVersion(value: String) =
+    CrossVersion(CrossVersion.constant(value), "dummy1", "dummy2") map (fn => fn("artefact"))
+
+  "CrossVersion.constant" should "add a constant to the version" in {
+    constantVersion("duck") shouldBe Some("artefact_duck")
+  }
+
   "Disabled" should "have structural equality" in {
     Disabled() shouldBe Disabled()
   }
@@ -238,5 +245,8 @@ class CrossVersionTest extends UnitSpec {
   }
   "CrossVersion.binary" should "have structural equality" in {
     CrossVersion.binary shouldBe CrossVersion.binary
+  }
+  "CrossVersion.constant" should "have structural equality" in {
+    CrossVersion.constant("duck") shouldBe CrossVersion.constant("duck")
   }
 }


### PR DESCRIPTION
sbt 1 removes CrossVersion.binaryMapped which was used in the sbt-dotty
plugin to provide a way to depend on Scala 2.x artifacts in a project
that cross-compiles between Scala 2.x and Dotty (see `withDottyCompat()` in
https://github.com/lampepfl/dotty/blob/master/sbt-dotty/src/dotty/tools/sbtplugin/DottyPlugin.scala).

Using `binaryWith` is not enough because it only allows the user to
specify a prefix and a suffix for the binary version which will always
be set to `scalaBinaryVersion`. This commit introduces a new `Constant`
kind of CrossVersion which allows the user to specify any string he
wants as a cross-version, thus making it possible to port
`withDottyCompat()` to sbt 1.