### PR TITLE
Fixes sbtApiVersion logic

### DIFF
--- a/core/src/main/scala/sbt/internal/librarymanagement/cross/CrossVersionUtil.scala
+++ b/core/src/main/scala/sbt/internal/librarymanagement/cross/CrossVersionUtil.scala
@@ -36,10 +36,13 @@ object CrossVersionUtil {
    * Compatible versions include 0.12.0-1 and 0.12.0-RC1 for Some(0, 12).
    */
   private[sbt] def sbtApiVersion(v: String): Option[(Long, Long)] = v match {
-    case ReleaseV(x, y, _, _)                     => Some(sbtApiVersion(x.toLong, y.toLong))
-    case CandidateV(x, y, _, _)                   => Some(sbtApiVersion(x.toLong, y.toLong))
-    case NonReleaseV_n(x, y, z, _) if z.toInt > 0 => Some(sbtApiVersion(x.toLong, y.toLong))
-    case _                                        => None
+    case ReleaseV(x, y, _, _)   => Some(sbtApiVersion(x.toLong, y.toLong))
+    case CandidateV(x, y, _, _) => Some(sbtApiVersion(x.toLong, y.toLong))
+    case NonReleaseV_n(x, y, z, _) if x.toLong == 0 && z.toLong > 0 =>
+      Some(sbtApiVersion(x.toLong, y.toLong))
+    case NonReleaseV_n(x, y, z, _) if x.toLong > 0 && (y.toLong > 0 || z.toLong > 0) =>
+      Some(sbtApiVersion(x.toLong, y.toLong))
+    case _                      => None
   }
 
   private def sbtApiVersion(x: Long, y: Long) = {

--- a/ivy/src/test/scala/CrossVersionTest.scala
+++ b/ivy/src/test/scala/CrossVersionTest.scala
@@ -135,6 +135,9 @@ class CrossVersionTest extends UnitSpec {
   it should "for 1.3.0 return 1.0" in {
     binarySbtVersion("1.3.0") shouldBe "1.0"
   }
+  it should "for 1.3.0-SNAPSHOT return 1.0" in {
+    binarySbtVersion("1.3.0-SNAPSHOT") shouldBe "1.0"
+  }
   it should "for 1.10.0 return 1.0" in {
     binarySbtVersion("1.10.0") shouldBe "1.0"
   }


### PR DESCRIPTION
The NonRelease pattern matcher is only checking for the third segment, but for sbt 1.x, we need to check both the second and third segment since 1.1.0-M1 would be bincompat with 1.0.

Fixes sbt/sbt#3360
