### PR TITLE
Use IvyAuthenticator and JavaNetAuthenticator

### DIFF
--- a/core/src/main/scala/sbt/internal/librarymanagement/cross/CrossVersionUtil.scala
+++ b/core/src/main/scala/sbt/internal/librarymanagement/cross/CrossVersionUtil.scala
@@ -36,10 +36,13 @@ object CrossVersionUtil {
    * Compatible versions include 0.12.0-1 and 0.12.0-RC1 for Some(0, 12).
    */
   private[sbt] def sbtApiVersion(v: String): Option[(Long, Long)] = v match {
-    case ReleaseV(x, y, _, _)                     => Some(sbtApiVersion(x.toLong, y.toLong))
-    case CandidateV(x, y, _, _)                   => Some(sbtApiVersion(x.toLong, y.toLong))
-    case NonReleaseV_n(x, y, z, _) if z.toInt > 0 => Some(sbtApiVersion(x.toLong, y.toLong))
-    case _                                        => None
+    case ReleaseV(x, y, _, _)   => Some(sbtApiVersion(x.toLong, y.toLong))
+    case CandidateV(x, y, _, _) => Some(sbtApiVersion(x.toLong, y.toLong))
+    case NonReleaseV_n(x, y, z, _) if x.toLong == 0 && z.toLong > 0 =>
+      Some(sbtApiVersion(x.toLong, y.toLong))
+    case NonReleaseV_n(x, y, z, _) if x.toLong > 0 && (y.toLong > 0 || z.toLong > 0) =>
+      Some(sbtApiVersion(x.toLong, y.toLong))
+    case _                      => None
   }
 
   private def sbtApiVersion(x: Long, y: Long) = {

--- a/core/src/main/scala/sbt/librarymanagement/Http.scala
+++ b/core/src/main/scala/sbt/librarymanagement/Http.scala
@@ -1,13 +1,7 @@
 package sbt.librarymanagement
 
 import gigahorse._, support.okhttp.Gigahorse
-import okhttp3.{ OkUrlFactory, OkHttpClient }
-import java.net.{ URL, HttpURLConnection }
 
 object Http {
   lazy val http: HttpClient = Gigahorse.http(Gigahorse.config)
-
-  private[sbt] lazy val urlFactory = new OkUrlFactory(http.underlying[OkHttpClient])
-  private[sbt] def open(url: URL): HttpURLConnection =
-    urlFactory.open(url)
 }

--- a/ivy/src/test/scala/CrossVersionTest.scala
+++ b/ivy/src/test/scala/CrossVersionTest.scala
@@ -135,6 +135,9 @@ class CrossVersionTest extends UnitSpec {
   it should "for 1.3.0 return 1.0" in {
     binarySbtVersion("1.3.0") shouldBe "1.0"
   }
+  it should "for 1.3.0-SNAPSHOT return 1.0" in {
+    binarySbtVersion("1.3.0-SNAPSHOT") shouldBe "1.0"
+  }
   it should "for 1.10.0 return 1.0" in {
     binarySbtVersion("1.10.0") shouldBe "1.0"
   }


### PR DESCRIPTION
This is on top of https://github.com/sbt/librarymanagement/pull/140

Fixes sbt/sbt#3331

The siatuation is a bit complicated.
Currently the credentials are stored in Ivy's credential store.
This needs to be translated into `java.net.Authenticator` by installing `IvyAuthenticator` and `ErrorMessageAuthenticator` in succession.
This, then, needs to be translated into OkHttp Authenticator using `okhttp3.JavaNetAuthenticator`.

Tested by publishing SNAPSHOT scopt to Sonatype.