### PR TITLE
Change overwrite warning

### DIFF
--- a/ivy/src/main/scala/sbt/internal/librarymanagement/ConvertResolver.scala
+++ b/ivy/src/main/scala/sbt/internal/librarymanagement/ConvertResolver.scala
@@ -400,10 +400,11 @@ private[sbt] object ConvertResolver {
       try super.put(source, destination, overwrite)
       catch {
         case e: java.io.IOException if e.getMessage.contains("destination already exists") =>
+          val overwriteWarning =
+            if (destination contains "-SNAPSHOT") s"Attempting to overwrite $destination"
+            else "Attempting to overwrite $destination (non-SNAPSHOT)\n\tYou need to remove it from the cache manually to take effect."
           import org.apache.ivy.util.Message
-          Message.warn(
-            s"Attempting to overwrite $destination\n\tThis usage is deprecated and will be removed in sbt 1.0."
-          )
+          Message.warn(overwriteWarning)
           super.put(source, destination, true)
       }
     }


### PR DESCRIPTION
Previously the warning read:

    Attempting to overwrite $destination
    This usage is deprecated and will be removed in sbt 1.0.

This is an empty threat since we did not remove the feature.

I'm replacing it with:

    Attempting to overwrite $destination (non-SNAPSHOT)
    You need to remove it from the cache manually to take effect.

Fixes sbt/sbt#3271