### PR TITLE
Let `ModuleDescriptor` declare cache inputs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -103,7 +103,9 @@ lazy val lmCore = (project in file("core"))
       // Was private[sbt] and manually checked to be unused in Zinc or sbt
       ProblemFilters.exclude[DirectMissingMethodProblem]("sbt.librarymanagement.Http.open"),
       // New methods added to LM API
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("sbt.librarymanagement.ModuleDescriptor.*"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("sbt.librarymanagement.ModuleDescriptor.moduleSettings"),
+      // New methods added to LM API
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("sbt.librarymanagement.ModuleDescriptor.extraInputHash"),
       // New formats for Logger and GlockLock
       ProblemFilters.exclude[ReversedMissingMethodProblem]("sbt.internal.librarymanagement.formats.*"),
     )

--- a/build.sbt
+++ b/build.sbt
@@ -104,6 +104,8 @@ lazy val lmCore = (project in file("core"))
       ProblemFilters.exclude[DirectMissingMethodProblem]("sbt.librarymanagement.Http.open"),
       // New methods added to LM API
       ProblemFilters.exclude[ReversedMissingMethodProblem]("sbt.librarymanagement.ModuleDescriptor.*"),
+      // New formats for Logger and GlockLock
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("sbt.internal.librarymanagement.formats.*"),
     )
   )
   .configure(addSbtIO, addSbtUtilLogging, addSbtUtilPosition, addSbtUtilCache)

--- a/build.sbt
+++ b/build.sbt
@@ -102,6 +102,8 @@ lazy val lmCore = (project in file("core"))
       // method open(java.net.URL)java.net.HttpURLConnection in object sbt.librarymanagement.Http does not have a correspondent in current version
       // Was private[sbt] and manually checked to be unused in Zinc or sbt
       ProblemFilters.exclude[DirectMissingMethodProblem]("sbt.librarymanagement.Http.open"),
+      // New methods added to LM API
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("sbt.librarymanagement.ModuleDescriptor.*"),
     )
   )
   .configure(addSbtIO, addSbtUtilLogging, addSbtUtilPosition, addSbtUtilCache)

--- a/core/src/main/scala/sbt/librarymanagement/LibraryManagementInterface.scala
+++ b/core/src/main/scala/sbt/librarymanagement/LibraryManagementInterface.scala
@@ -81,4 +81,14 @@ trait ModuleDescriptor {
    * if any.
    */
   def scalaModuleInfo: Option[ScalaModuleInfo]
+
+  /**
+   * The input parameters used to construct the `ModuleSettings`.
+   */
+  def moduleSettings: ModuleSettings
+
+  /**
+   * Hash for extra parameter that were not captured as `moduleSettings`.
+   */
+  def extraInputHash: Long
 }


### PR DESCRIPTION
Added `moduleSettings` and `extraInputHash`.

```scala
scala> import java.io.File
import java.io.File

scala> import sbt.librarymanagement._, syntax._
import sbt.librarymanagement._
import syntax._

scala> val log = sbt.util.LogExchange.logger("test")
log: sbt.internal.util.ManagedLogger = sbt.internal.util.ManagedLogger@3619665d

scala> val lm = {
                import sbt.librarymanagement.ivy._
                val ivyConfig = InlineIvyConfiguration().withLog(log)
                IvyDependencyResolution(ivyConfig)
              }
lm: sbt.librarymanagement.DependencyResolution = sbt.librarymanagement.DependencyResolution@830853

scala> val dep = "commons-io" % "commons-io" % "2.5"
dep: sbt.librarymanagement.ModuleID = commons-io:commons-io:2.5

scala> val m = lm.wrapDependencyInModule(dep)
m: sbt.librarymanagement.ModuleDescriptor = sbt.internal.librarymanagement.IvySbt$Module@607b721b

scala> m.moduleSettings
res0: sbt.librarymanagement.ModuleSettings = ModuleDescriptorConfiguration(false, None, org.scala-sbt.temp:temp-module-79d4810e28d241fcfc983cb6e9b221180c05c2fe:2.5, ModuleInfo(temp-module-79d4810e28d241fcfc983cb6e9b221180c05c2fe, , None, None, Vector(), , None, None, Vector()), Vector(commons-io:commons-io:2.5), Vector(), Vector(), , Vector(compile, runtime, test, provided, optional), Some(compile), ConflictManager(latest-revision, *, *))

scala> m.extraInputHash
res1: Long = -990812122
```
