### PR TITLE
Include sbt plugin extra attributes in cached resolution

### DIFF
--- a/core/src/main/scala/sbt/librarymanagement/UpdateReportExtra.scala
+++ b/core/src/main/scala/sbt/librarymanagement/UpdateReportExtra.scala
@@ -70,7 +70,7 @@ abstract class ModuleReportExtra {
       reportStr("problem", problem) +
       reportStr("homepage", homepage) +
       reportStr(
-        "textraAttributes",
+        "extraAttributes",
         if (extraAttributes.isEmpty) None
         else { Some(extraAttributes.toString) }
       ) +


### PR DESCRIPTION
I don't think it will be common to hit this, but something that we found in the Cinnamon build and needed to disable cached resolution. When cached resolution is enabled and a cross-built sbt plugin depends on another cross-built sbt plugin, then the resolution will reuse the cached dependency from whatever is resolved first — so you have an sbt 1.0 dependency for sbt 0.13 or the other way around.

The regular ivy cache includes the scala version and sbt version extra attributes in the path (such as `scala_2.12/sbt_1.0/` or `scala_2.10/sbt_0.13/` based on the ivy cache pattern. Add something similar for cached resolution.

Could be backported to sbt 0.13 as well.

Also, when trying this out with sbt 1.0, I needed to also set the metadata directory to enable cached resolution. Not sure if this was expected. So I needed to add:

```scala
updateOptions := updateOptions.value.withCachedResolution(true)
```

but also:

```scala
updateConfiguration := updateConfiguration.value.withMetadataDirectory(Some(path / to / dir))
```


