### PR TITLE
Remove deprecated OkHTTP OkUrlFactory

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,16 @@ def commonSettings: Seq[Setting[_]] = Seq(
 )
 
 val mimaSettings = Def settings (
-  mimaPreviousArtifacts := Set(organization.value %% moduleName.value % "1.0.0")
+  mimaPreviousArtifacts := Set(organization.value %% moduleName.value % "1.0.0"),
+  mimaBinaryIssueFilters ++= {
+    import com.typesafe.tools.mima.core._
+    import com.typesafe.tools.mima.core.ProblemFilters._
+    Seq(
+      exclude[DirectMissingMethodProblem]("sbt.internal.librarymanagement.ivyint.GigahorseUrlHandler#SbtUrlInfo.this"),
+      exclude[IncompatibleMethTypeProblem]("sbt.internal.librarymanagement.ivyint.GigahorseUrlHandler#SbtUrlInfo.this"),
+      exclude[DirectMissingMethodProblem]("sbt.internal.librarymanagement.ivyint.GigahorseUrlHandler.checkStatusCode")
+    )
+  }
 )
 
 lazy val lmRoot = (project in file("."))

--- a/ivy/src/main/scala/sbt/internal/librarymanagement/ivyint/GigahorseUrlHandler.scala
+++ b/ivy/src/main/scala/sbt/internal/librarymanagement/ivyint/GigahorseUrlHandler.scala
@@ -225,10 +225,12 @@ object GigahorseUrlHandler {
       .build
   }
 
+  @deprecated("Use the Gigahorse HttpClient directly instead.", "librarymanagement-ivy 1.0.1")
   private[sbt] def urlFactory = {
     new OkUrlFactory(okHttpClient)
   }
 
+  @deprecated("Use the Gigahorse HttpClient directly instead.", "librarymanagement-ivy 1.0.1")
   private[sbt] def open(url: URL): HttpURLConnection =
     urlFactory.open(url)
 


### PR DESCRIPTION
- Replace usage of OkUrlFactory with just direct calls to the OkHTTP API. This allows us to ensure that connections get properly closed, and provides finer-grained internal control of how we make http requests.

- Ensure that exceptions/error status codes don't cause leaked or hanging connections. Previously, a 404 on an artifact download would cause the underlying OkHTTP client to keep the request and connection open. This has the effect of wasting resources, but also slowing down overall download/resolution time to non-pipelined HTTP servers.