### PR TITLE
Removed extra slash in the localBasePattern

### DIFF
--- a/core/src/main/scala/sbt/librarymanagement/ResolverExtra.scala
+++ b/core/src/main/scala/sbt/librarymanagement/ResolverExtra.scala
@@ -357,7 +357,7 @@ abstract class ResolverFunctions {
   def mavenStyleBasePattern =
     "[organisation]/[module](_[scalaVersion])(_[sbtVersion])/[revision]/[artifact]-[revision](-[classifier]).[ext]"
   def localBasePattern =
-    "[organisation]/[module]/" + PluginPattern + "(/[branch])/[revision]/[type]s/[artifact](-[classifier]).[ext]"
+    "[organisation]/[module]/" + PluginPattern + "([branch]/)[revision]/[type]s/[artifact](-[classifier]).[ext]"
   def defaultRetrievePattern =
     "[type]s/[organisation]/[module]/" + PluginPattern + "[artifact](-[revision])(-[classifier]).[ext]"
   final val PluginPattern = "(scala_[scalaVersion]/)(sbt_[sbtVersion]/)"


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/3573 and https://github.com/ohnosequences/sbt-s3-resolver/issues/52.

When the `scala_[scalaVersion]/` segment (and/or the `PluginPattern` part) is present and the `/[branch]` segment isn't, an extra slash appears before `/[revision]`. This may cause some problem (see the linked issues).

Here is a comparison of the `localBasePattern` in sbt 0.13 vs 1.0+:

```
[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext])
[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)(/[branch])/[revision]/[type]s/[artifact](-[classifier]).[ext])
                                                                             ^
```
