### PR TITLE
Bump Ivy to 2.3.0-sbt-1b57d3bbc08ecf671169fd548918da18c91f77be

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -40,7 +40,7 @@ object Dependencies {
   def addSbtUtilCache(p: Project): Project = addSbtModule(p, sbtUtilPath, "utilCache", utilCache)
 
   val launcherInterface = "org.scala-sbt" % "launcher-interface" % "1.0.0"
-  val ivy = "org.scala-sbt.ivy" % "ivy" % "2.3.0-sbt-a3314352b638afbf0dca19f127e8263ed6f898bd"
+  val ivy = "org.scala-sbt.ivy" % "ivy" % "2.3.0-sbt-1b57d3bbc08ecf671169fd548918da18c91f77be"
   val jsch = "com.jcraft" % "jsch" % "0.1.46" intransitive ()
   val scalaReflect = Def.setting { "org.scala-lang" % "scala-reflect" % scalaVersion.value }
   val scalaCompiler = Def.setting { "org.scala-lang" % "scala-compiler" % scalaVersion.value }


### PR DESCRIPTION
Ref https://github.com/sbt/ivy/pull/26
Ref sbt/launcher#38

JDK 9 complains when java.lang.reflect.Field#setAccessible is called. So on
JDK 9 to get the default Authenticator on JDK you can just call
Authenticator.getDefault(). However ivy targets JDK 6..

So on JDK < 9 we do what we've always done, and on JDK 9+ we use java
reflection to call Authenticator.getDefault(), which is public and doesn't
require setAccessible(true).