### PR TITLE
Be friendly to SBT plugins that also use URLHandlerRegistry.setDefault

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ scala:
   - 2.11.11
   - 2.12.3
 
+matrix:
+  include:
+  - scala: 2.12.3
+    jdk: oraclejdk9
+
 script:
   - sbt -Dfile.encoding=UTF8 -J-XX:ReservedCodeCacheSize=256M ";++$TRAVIS_SCALA_VERSION;mimaReportBinaryIssues;scalafmt::test;test:scalafmt::test;sbt:scalafmt::test;test"
 

--- a/core/src/main/scala/sbt/librarymanagement/EvictionWarning.scala
+++ b/core/src/main/scala/sbt/librarymanagement/EvictionWarning.scala
@@ -283,7 +283,7 @@ object EvictionWarning {
       out += "Scala version was updated by one of library dependencies:"
       out ++= (a.scalaEvictions flatMap { _.lines })
       out += "To force scalaVersion, add the following:"
-      out += "\tivyScala := ivyScala.value map { _.copy(overrideScalaVersion = true) }"
+      out += "\tscalaModuleInfo ~= (_.map(_.withOverrideScalaVersion(true)))"
     }
 
     if (a.directEvictions.nonEmpty || a.transitiveEvictions.nonEmpty) {

--- a/ivy/src/main/scala/sbt/internal/librarymanagement/ConvertResolver.scala
+++ b/ivy/src/main/scala/sbt/internal/librarymanagement/ConvertResolver.scala
@@ -399,7 +399,7 @@ private[sbt] object ConvertResolver {
           val overwriteWarning =
             if (destination contains "-SNAPSHOT") s"Attempting to overwrite $destination"
             else
-              "Attempting to overwrite $destination (non-SNAPSHOT)\n\tYou need to remove it from the cache manually to take effect."
+              s"Attempting to overwrite $destination (non-SNAPSHOT)\n\tYou need to remove it from the cache manually to take effect."
           import org.apache.ivy.util.Message
           Message.warn(overwriteWarning)
           super.put(source, destination, true)

--- a/ivy/src/main/scala/sbt/internal/librarymanagement/Ivy.scala
+++ b/ivy/src/main/scala/sbt/internal/librarymanagement/Ivy.scala
@@ -80,16 +80,29 @@ final class IvySbt(val configuration: IvyConfiguration) { self =>
   }
 
   private lazy val basicUrlHandler: URLHandler = new BasicURLHandler
-  private lazy val gigahorseUrlHandler: URLHandler = {
-    val dispatcher = new URLHandlerDispatcher
-    val handler = new GigahorseUrlHandler
-    dispatcher.setDownloader("http", handler)
-    dispatcher.setDownloader("https", handler)
-    dispatcher
-  }
+  private lazy val gigahorseUrlHandler: URLHandler = new GigahorseUrlHandler
+
   private lazy val settings: IvySettings = {
-    if (configuration.updateOptions.gigahorse) URLHandlerRegistry.setDefault(gigahorseUrlHandler)
-    else URLHandlerRegistry.setDefault(basicUrlHandler)
+    val dispatcher: URLHandlerDispatcher = URLHandlerRegistry.getDefault match {
+      // If the default is already a URLHandlerDispatcher then just use that
+      case disp: URLHandlerDispatcher => disp
+
+      // Otherwise wrap the existing URLHandler in a URLHandlerDispatcher
+      // while retaining the existing URLHandler as the default.
+      case default =>
+        val disp: URLHandlerDispatcher = new URLHandlerDispatcher()
+        disp.setDefault(default)
+        URLHandlerRegistry.setDefault(disp)
+        disp
+    }
+
+    val urlHandler: URLHandler = if (configuration.updateOptions.gigahorse) gigahorseUrlHandler else basicUrlHandler
+
+    // Only set the urlHandler for the http/https protocols so we do not conflict with any other plugins
+    // that might register other protocol handlers.
+    // For example https://github.com/frugalmechanic/fm-sbt-s3-resolver registers "s3"
+    dispatcher.setDownloader("http", urlHandler)
+    dispatcher.setDownloader("https", urlHandler)
 
     val is = new IvySettings
     is.setCircularDependencyStrategy(

--- a/ivy/src/test/scala/EvictionWarningSpec.scala
+++ b/ivy/src/test/scala/EvictionWarningSpec.scala
@@ -93,7 +93,7 @@ class EvictionWarningSpec extends BaseIvySpecification {
         "\t* org.scala-lang:scala-library:2.10.3 is selected over 2.10.2",
         "",
         "To force scalaVersion, add the following:",
-        "\tivyScala := ivyScala.value map { _.copy(overrideScalaVersion = true) }",
+        "\tscalaModuleInfo ~= (_.map(_.withOverrideScalaVersion(true)))",
         "Run 'evicted' to see detailed eviction warnings"
       )
   }
@@ -109,7 +109,7 @@ class EvictionWarningSpec extends BaseIvySpecification {
         "\t    +- com.example:foo:0.1.0                              (depends on 2.10.2)",
         "",
         "To force scalaVersion, add the following:",
-        "\tivyScala := ivyScala.value map { _.copy(overrideScalaVersion = true) }",
+        "\tscalaModuleInfo ~= (_.map(_.withOverrideScalaVersion(true)))",
         "Run 'evicted' to see detailed eviction warnings"
       )
   }


### PR DESCRIPTION
Other plugins (for example: https://github.com/frugalmechanic/fm-sbt-s3-resolver)
also make use of the URLHandlerRegistry.setDefault mechanism to register handlers
for other protocols (e.g. "s3").  This change makes it so that SBT will only
register the http/https protocols and will preserve any other protocol handlers
that have already been registered.

**NOTE: This has now been tested and fixes https://github.com/sbt/librarymanagement/issues/175**
