### PR TITLE
Convert lastModified() calls to the more precise getModifiedTime()

### DIFF
--- a/core/src/main/scala/sbt/librarymanagement/RichUpdateReport.scala
+++ b/core/src/main/scala/sbt/librarymanagement/RichUpdateReport.scala
@@ -3,7 +3,7 @@ package librarymanagement
 
 import java.io.File
 import java.io.FileNotFoundException
-import sbt.io.IO.getModifiedTime
+import sbt.io.IO
 
 /**
  * Provides extra methods for filtering the contents of an `UpdateReport`
@@ -20,11 +20,10 @@ final class RichUpdateReport(report: UpdateReport) {
            // On occasion, "files" contains files like "./target/ivyhome/resolution-cache/com.example/foo/0.4.0/resolved.xml.xml",
            // which do not actually exist, so getModifiedTime() correctly throws an exception. For the moment, the behavior of
            // lastModified() is reproduced, but the non-existent file should really not be there to begin with. so, FIXME.
-           try {
-             getModifiedTime(f)
-           } catch {
-             case _: FileNotFoundException => 0L
-           }))
+           try IO.getModifiedTime(f)
+           catch { case _: FileNotFoundException => 0L }
+         )
+      )
       .toMap
     UpdateReport(report.cachedDescriptor, report.configurations, report.stats, stamps)
   }

--- a/core/src/main/scala/sbt/librarymanagement/RichUpdateReport.scala
+++ b/core/src/main/scala/sbt/librarymanagement/RichUpdateReport.scala
@@ -3,7 +3,7 @@ package librarymanagement
 
 import java.io.File
 import java.io.FileNotFoundException
-import sbt.io.Milli.getModifiedTime
+import sbt.io.IO.getModifiedTime
 
 /**
  * Provides extra methods for filtering the contents of an `UpdateReport`

--- a/core/src/main/scala/sbt/librarymanagement/RichUpdateReport.scala
+++ b/core/src/main/scala/sbt/librarymanagement/RichUpdateReport.scala
@@ -2,6 +2,7 @@ package sbt
 package librarymanagement
 
 import java.io.File
+import sbt.io.Milli.getModifiedTime
 
 /**
  * Provides extra methods for filtering the contents of an `UpdateReport`
@@ -10,7 +11,7 @@ import java.io.File
 final class RichUpdateReport(report: UpdateReport) {
   private[sbt] def recomputeStamps(): UpdateReport = {
     val files = report.cachedDescriptor +: allFiles
-    val stamps = files.map(f => (f, f.lastModified)).toMap
+    val stamps = files.map(f => (f, getModifiedTime(f))).toMap
     UpdateReport(report.cachedDescriptor, report.configurations, report.stats, stamps)
   }
 

--- a/ivy/src/main/scala/sbt/internal/librarymanagement/ivyint/GigahorseUrlHandler.scala
+++ b/ivy/src/main/scala/sbt/internal/librarymanagement/ivyint/GigahorseUrlHandler.scala
@@ -16,7 +16,6 @@ import org.apache.ivy.util.{ CopyProgressEvent, CopyProgressListener, Message }
 import org.apache.ivy.util.url.{ AbstractURLHandler, BasicURLHandler, IvyAuthenticator, URLHandler }
 import org.apache.ivy.util.url.URLHandler._
 import sbt.io.IO
-import sbt.io.Milli.setModifiedTime
 
 // Copied from Ivy's BasicURLHandler.
 class GigahorseUrlHandler extends AbstractURLHandler {
@@ -150,7 +149,7 @@ class GigahorseUrlHandler extends AbstractURLHandler {
 
       val lastModified = lastModifiedTimestamp(response)
       if (lastModified > 0) {
-        setModifiedTime(dest, lastModified)
+        IO.setModifiedTime(dest, lastModified)
       }
 
       if (l != null) {

--- a/ivy/src/main/scala/sbt/internal/librarymanagement/ivyint/GigahorseUrlHandler.scala
+++ b/ivy/src/main/scala/sbt/internal/librarymanagement/ivyint/GigahorseUrlHandler.scala
@@ -16,6 +16,7 @@ import org.apache.ivy.util.{ CopyProgressEvent, CopyProgressListener, Message }
 import org.apache.ivy.util.url.{ AbstractURLHandler, BasicURLHandler, IvyAuthenticator, URLHandler }
 import org.apache.ivy.util.url.URLHandler._
 import sbt.io.IO
+import sbt.io.Milli.setModifiedTime
 
 // Copied from Ivy's BasicURLHandler.
 class GigahorseUrlHandler extends AbstractURLHandler {
@@ -149,7 +150,7 @@ class GigahorseUrlHandler extends AbstractURLHandler {
 
       val lastModified = lastModifiedTimestamp(response)
       if (lastModified > 0) {
-        dest.setLastModified(lastModified)
+        setModifiedTime(dest, lastModified)
       }
 
       if (l != null) {

--- a/project/Util.scala
+++ b/project/Util.scala
@@ -26,6 +26,8 @@ object Util {
     val timestamp = formatter.format(new Date)
     val content = versionLine(version) + "\ntimestamp=" + timestamp
     val f = dir / "xsbt.version.properties"
+    // TODO: replace lastModified() with sbt.io.Milli.getModifiedTime(), once the build
+    // has been upgraded to a version of sbt that includes sbt.io.Milli.
     if (!f.exists || f.lastModified < lastCompilationTime(analysis) || !containsVersion(f, version)) {
       s.log.info("Writing version information to " + f + " :\n" + content)
       IO.write(f, content)


### PR DESCRIPTION
Use the new native file modification timestamps, which return times with full millisecond precisions whenever possible.
Depends on https://github.com/sbt/util/pull/134
See: https://github.com/sbt/io/pull/92
