### PR TITLE
Use IO.getModifiedTimeOrZero(file) calls

### DIFF
--- a/core/src/main/scala/sbt/librarymanagement/RichUpdateReport.scala
+++ b/core/src/main/scala/sbt/librarymanagement/RichUpdateReport.scala
@@ -18,9 +18,9 @@ final class RichUpdateReport(report: UpdateReport) {
           (f,
            // TODO: The list of files may also contain some odd files that do not actually exist like:
            // "./target/ivyhome/resolution-cache/com.example/foo/0.4.0/resolved.xml.xml".
-           // IO.lastModified() will just return zero, but the list of files should not contain such
+           // IO.getModifiedTimeOrZero() will just return zero, but the list of files should not contain such
            // files to begin with, in principle.
-           IO.lastModified(f)
+           IO.getModifiedTimeOrZero(f))
       )
       .toMap
     UpdateReport(report.cachedDescriptor, report.configurations, report.stats, stamps)

--- a/core/src/main/scala/sbt/librarymanagement/RichUpdateReport.scala
+++ b/core/src/main/scala/sbt/librarymanagement/RichUpdateReport.scala
@@ -16,12 +16,11 @@ final class RichUpdateReport(report: UpdateReport) {
       .map(
         f =>
           (f,
-           // TODO: this used to be a lastModified(), without error checking.
-           // On occasion, "files" contains files like "./target/ivyhome/resolution-cache/com.example/foo/0.4.0/resolved.xml.xml",
-           // which do not actually exist, so getModifiedTime() correctly throws an exception. For the moment, the behavior of
-           // lastModified() is reproduced, but the non-existent file should really not be there to begin with. so, FIXME.
-           try IO.getModifiedTime(f)
-           catch { case _: FileNotFoundException => 0L })
+           // TODO: The list of files may also contain some odd files that do not actually exist like:
+           // "./target/ivyhome/resolution-cache/com.example/foo/0.4.0/resolved.xml.xml".
+           // IO.lastModified() will just return zero, but the list of files should not contain such
+           // files to begin with, in principle.
+           IO.lastModified(f)
       )
       .toMap
     UpdateReport(report.cachedDescriptor, report.configurations, report.stats, stamps)

--- a/ivy/src/main/scala/sbt/internal/librarymanagement/ivyint/GigahorseUrlHandler.scala
+++ b/ivy/src/main/scala/sbt/internal/librarymanagement/ivyint/GigahorseUrlHandler.scala
@@ -149,7 +149,7 @@ class GigahorseUrlHandler extends AbstractURLHandler {
 
       val lastModified = lastModifiedTimestamp(response)
       if (lastModified > 0) {
-        IO.setLastModified(dest, lastModified)
+        IO.setModifiedTimeOrFalse(dest, lastModified)
       }
 
       if (l != null) {

--- a/ivy/src/main/scala/sbt/internal/librarymanagement/ivyint/GigahorseUrlHandler.scala
+++ b/ivy/src/main/scala/sbt/internal/librarymanagement/ivyint/GigahorseUrlHandler.scala
@@ -149,7 +149,7 @@ class GigahorseUrlHandler extends AbstractURLHandler {
 
       val lastModified = lastModifiedTimestamp(response)
       if (lastModified > 0) {
-        IO.setModifiedTime(dest, lastModified)
+        IO.setLastModified(dest, lastModified)
       }
 
       if (l != null) {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,8 +6,8 @@ object Dependencies {
   val scala211 = "2.11.12"
   val scala212 = "2.12.4"
 
-  private val ioVersion = "1.1.2"
-  private val utilVersion = "1.1.1"
+  private val ioVersion = "1.1.3"
+  private val utilVersion = "1.1.2"
 
   private val sbtIO = "org.scala-sbt" %% "io" % ioVersion
 

--- a/project/Util.scala
+++ b/project/Util.scala
@@ -26,8 +26,8 @@ object Util {
     val timestamp = formatter.format(new Date)
     val content = versionLine(version) + "\ntimestamp=" + timestamp
     val f = dir / "xsbt.version.properties"
-    // TODO: replace lastModified() with sbt.io.Milli.getModifiedTime(), once the build
-    // has been upgraded to a version of sbt that includes sbt.io.Milli.
+    // TODO: replace lastModified() with sbt.io.IO.lastModified(), once the build
+    // has been upgraded to a version of sbt that includes that call.
     if (!f.exists || f.lastModified < lastCompilationTime(analysis) || !containsVersion(f, version)) {
       s.log.info("Writing version information to " + f + " :\n" + content)
       IO.write(f, content)

--- a/project/Util.scala
+++ b/project/Util.scala
@@ -26,7 +26,7 @@ object Util {
     val timestamp = formatter.format(new Date)
     val content = versionLine(version) + "\ntimestamp=" + timestamp
     val f = dir / "xsbt.version.properties"
-    // TODO: replace lastModified() with sbt.io.IO.lastModified(), once the build
+    // TODO: replace lastModified() with sbt.io.IO.getModifiedTimeOrZero(), once the build
     // has been upgraded to a version of sbt that includes that call.
     if (!f.exists || f.lastModified < lastCompilationTime(analysis) || !containsVersion(f, version)) {
       s.log.info("Writing version information to " + f + " :\n" + content)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.0
+sbt.version=1.0.4


### PR DESCRIPTION
There are just too many instances in which sbt's code relies on
the `lastModified`/`setLastModified` semantics, so instead of moving
to `get`/`setModifiedTime`, we use new IO calls that offer the new
timestamp precision, but retain the old semantics.