### PR TITLE
Adds null check for 'sbt.managedChecksums' in ivySettings fixing #195

### DIFF
--- a/ivy/src/main/scala/sbt/internal/librarymanagement/IvyActions.scala
+++ b/ivy/src/main/scala/sbt/internal/librarymanagement/IvyActions.scala
@@ -4,26 +4,29 @@
 package sbt.internal.librarymanagement
 
 import java.io.File
-import ivyint.CachedResolutionResolveEngine
 
+import ivyint.CachedResolutionResolveEngine
 import org.apache.ivy.Ivy
 import org.apache.ivy.core.{ IvyPatternHelper, LogOptions }
 import org.apache.ivy.core.deliver.DeliverOptions
 import org.apache.ivy.core.install.InstallOptions
 import org.apache.ivy.core.module.descriptor.{
-  Artifact => IArtifact,
+  DefaultModuleDescriptor,
   MDArtifact,
   ModuleDescriptor,
-  DefaultModuleDescriptor
+  Artifact => IArtifact
 }
 import org.apache.ivy.core.resolve.ResolveOptions
 import org.apache.ivy.plugins.resolver.{ BasicResolver, DependencyResolver }
 import org.apache.ivy.util.filter.{ Filter => IvyFilter }
 import sbt.io.{ IO, PathFinder }
 import sbt.util.Logger
-import sbt.librarymanagement.{ ModuleDescriptorConfiguration => InlineConfiguration, _ }, syntax._
+import sbt.librarymanagement.{ ModuleDescriptorConfiguration => InlineConfiguration, _ }
+import syntax._
 import InternalDefaults._
 import UpdateClassifiersUtil._
+
+import scala.util.Try
 
 object IvyActions {
 
@@ -382,7 +385,9 @@ object IvyActions {
       report: UpdateReport,
       config: RetrieveConfiguration
   ): UpdateReport = {
-    val copyChecksums = ivy.getVariable(ConvertResolver.ManagedChecksums).toBoolean
+    val copyChecksums =
+      Try(ivy.getVariable(ConvertResolver.ManagedChecksums).toBoolean).getOrElse(false)
+    val testerino = "PLEASE LOL "
     val toRetrieve: Option[Vector[ConfigRef]] = config.configurationsToRetrieve
     val base = getRetrieveDirectory(config.retrieveDirectory)
     val pattern = getRetrievePattern(config.outputPattern)


### PR DESCRIPTION
Sorry for the messy diff. I chose to leave all of the changes in, as most of the newline spacing was performed by scalafmt. If the maintainer wishes, I can fix this.

This PR adds a simple null check to protect against `"null"` from being parsed as a boolean.

Thanks for your time!