### PR TITLE
Cache the hashCode of Configuration

### DIFF
--- a/core/src/main/scala/sbt/librarymanagement/Configuration.scala
+++ b/core/src/main/scala/sbt/librarymanagement/Configuration.scala
@@ -31,7 +31,7 @@ final class Configuration private[sbt] (
         (this.transitive == x.transitive)
     case _ => false
   }
-  override def hashCode: Int = {
+  override val hashCode: Int = {
     37 * (37 * (37 * (37 * (37 * (37 * (17 + id.##) + name.##) + description.##) + isPublic.##) + extendsConfigs.##) + transitive.##)
   }
   override def toString: String = {


### PR DESCRIPTION
I noticed this was showing up in profiles when SBT's task engine
was using Keys, etc (that contain Configurations) in HashMap's.

Let's cache it instead. I don't think there is a need to use a lazy
val for this, we can compute it eagerly.