### PR TITLE
Fix to issue #180 to handle null contentType

### DIFF
--- a/ivy/src/main/scala/sbt/internal/librarymanagement/ivyint/GigahorseUrlHandler.scala
+++ b/ivy/src/main/scala/sbt/internal/librarymanagement/ivyint/GigahorseUrlHandler.scala
@@ -51,7 +51,7 @@ class GigahorseUrlHandler extends AbstractURLHandler {
 
         if (checkStatusCode(url, response)) {
           val bodyCharset =
-            BasicURLHandler.getCharSetFromContentType(response.body().contentType().toString)
+            BasicURLHandler.getCharSetFromContentType(Option(response.body().contentType()).map(_.toString).orNull)
           Some(
             new SbtUrlInfo(true,
                            response.body().contentLength(),


### PR DESCRIPTION
Fixes https://github.com/sbt/librarymanagement/issues/180

If the content type is null, the call for .toString on it will cause an NPE. This fixes this issue by wrapping the call in an Option, then mapping toString or falling back to null. getCharSetFromContentType handles null by returning ISO-8859-1