### PR TITLE
allow wildcards in groupId or artifactId

### DIFF
--- a/ivy/src/main/scala/sbt/internal/librarymanagement/MakePom.scala
+++ b/ivy/src/main/scala/sbt/internal/librarymanagement/MakePom.scala
@@ -425,7 +425,7 @@ class MakePom(val log: Logger) {
   def makeExclusion(exclRule: ExcludeRule): Either[String, NodeSeq] = {
     val m = exclRule.getId.getModuleId
     val (g, a) = (m.getOrganisation, m.getName)
-    if (g == null || g.isEmpty || g == "*" || a.isEmpty || a == "*")
+    if (g == null || g.isEmpty || a == null || a.isEmpty)
       Left(
         "Skipped generating '<exclusion/>' for %s. Dependency exclusion should have both 'org' and 'module' to comply with Maven POM's schema."
           .format(m)

--- a/ivy/src/test/scala/InclExclSpec.scala
+++ b/ivy/src/test/scala/InclExclSpec.scala
@@ -27,6 +27,13 @@ class InclExclSpec extends BaseIvySpecification {
     )
   }
 
+  def testScalaLibraryIsMissing(report: UpdateReport): Assertion = {
+    assert(
+      !report.allModules.exists(_.name.contains("scala-library")),
+      "scala-library has not been excluded."
+    )
+  }
+
   def testScalahostIsMissing(report: UpdateReport): Assertion = {
     assert(
       !report.allModules.exists(_.name.contains("scalahost")),
@@ -64,5 +71,17 @@ class InclExclSpec extends BaseIvySpecification {
     val excluded = new OrganizationArtifactName("net.liftweb", "lift-json", CrossVersion.full)
     val report = getIvyReport(createMetaDep(excluded), scala2122)
     testScalahostIsMissing(report)
+  }
+
+  it should "exclude any version of scala-library via * artifact id" in {
+    val toExclude = ExclusionRule("org.scala-lang", "*")
+    val report = getIvyReport(createLiftDep(toExclude), scala210)
+    testScalaLibraryIsMissing(report)
+  }
+
+  it should "exclude any version of scala-library via * org id" in {
+    val toExclude = ExclusionRule("*", "scala-library")
+    val report = getIvyReport(createLiftDep(toExclude), scala210)
+    testScalaLibraryIsMissing(report)
   }
 }


### PR DESCRIPTION
According to https://maven.apache.org/pom.html#Exclusions (and https://maven.apache.org/docs/3.2.1/release-notes.html) wildcards are allowed in Maven POM's schema