### PR TITLE
Fix sftp

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,11 @@ import Dependencies._
 import Path._
 import com.typesafe.tools.mima.core._, ProblemFilters._
 
+val _ = {
+  sys.props += ("line.separator" -> "\n")
+  sys.props += ("file.separaror" -> "/")
+}
+
 def commonSettings: Seq[Setting[_]] = Seq(
   scalaVersion := scala212,
   // publishArtifact in packageDoc := false,

--- a/build.sbt
+++ b/build.sbt
@@ -3,8 +3,8 @@ import Path._
 import com.typesafe.tools.mima.core._, ProblemFilters._
 
 val _ = {
+  //https://github.com/sbt/contraband/issues/122
   sys.props += ("line.separator" -> "\n")
-  sys.props += ("file.separaror" -> "/")
 }
 
 def commonSettings: Seq[Setting[_]] = Seq(

--- a/ivy/src/test/scala/sbt/internal/librarymanagement/SftpRepoSpec.scala
+++ b/ivy/src/test/scala/sbt/internal/librarymanagement/SftpRepoSpec.scala
@@ -1,0 +1,42 @@
+package sbt.internal.librarymanagement
+
+import sbt.io._
+import sbt.io.syntax._
+import sbt.util.Level
+import sbt.librarymanagement._
+import sbt.librarymanagement.syntax._
+import java.nio.file.Paths
+
+//by default this test is ignored
+//to run this you need to change "repo" to point to some sftp repository which contains a dependency referring a dependency in same repo
+//it will then attempt to authenticate via key file and fetch the dependency specified via "org" and "module"
+class SftpRepoSpec extends BaseIvySpecification {
+  val repo: Option[String] = None
+//  val repo: Option[String] = Some("some repo")
+  //a dependency which depends on another in the repo
+  def org(repo: String) = s"com.${repo}"
+  def module(org: String) = org % "some-lib" % "version"
+
+  override def resolvers = {
+    implicit val patterns = Resolver.defaultIvyPatterns
+    repo.map { repo =>
+      val privateKeyFile = Paths.get(sys.env("HOME"), ".ssh", s"id_${repo}").toFile
+      Resolver.sftp(repo, s"repo.${repo}.com", 2222).as(repo, privateKeyFile)
+    }.toVector ++ super.resolvers
+  }
+
+  "resolving multiple deps from sftp repo" should "not hang or fail" in {
+    repo match {
+      case Some(repo) =>
+        IO.delete(currentTarget / "cache" / org(repo))
+        //    log.setLevel(Level.Debug)
+        lmEngine().retrieve(module(org(repo)), scalaModuleInfo = None, currentTarget, log) match {
+          case Right(v) => log.debug(v.toString())
+          case Left(e) =>
+            log.log(Level.Error, e.failedPaths.toString())
+            throw e.resolveException
+        }
+      case None => log.info(s"skipped ${getClass}")
+    }
+  }
+}


### PR DESCRIPTION
another attempt to tackle https://github.com/sbt/sbt/issues/3738 , this time more informed
the included test requires a live sftp repo, so it's tailored to my environment and is ignored otherwise

note that there are two tests currently failing:
```
[info] OfflineModeSpec:
[info] Offline update configuration
[info] - should reuse the caches when offline is enabled
[info] - should reuse the caches when offline and cached resolution are enabled *** FAILED ***
[info]   java.io.IOException: CreateFile() failed with error 3
[info]   at sbt.internal.io.WinMilli$.getHandle(Milli.scala:275)
[info]   at sbt.internal.io.WinMilli$.getModifiedTimeNative(Milli.scala:281)
[info]   at sbt.internal.io.WinMilli$.getModifiedTimeNative(Milli.scala:259)
[info]   at sbt.internal.io.MilliNative.getModifiedTime(Milli.scala:66)
[info]   at sbt.internal.io.Milli$.getModifiedTime(Milli.scala:352)
[info]   at sbt.io.IO$.getModifiedTime(IO.scala:1143)
[info]   at sbt.io.IO$.getModifiedTimeOrZero(IO.scala:1212)
[info]   at sbt.librarymanagement.RichUpdateReport.$anonfun$recomputeStamps$1(RichUpdateReport.scala:23)
[info]   at scala.collection.TraversableLike.$anonfun$map$1(TraversableLike.scala:234)
[info]   at scala.collection.Iterator.foreach(Iterator.scala:929)
[info]   ...
[info] - should fail when artifacts are missing in the cache
[info] - should fail when artifacts are missing in the cache for cached resolution
```
```
[info] CachedResolutionSpec:
[info] Resolving the same module twice
[info] - should work
[info] Resolving the unsolvable module should
[info] - should not work
[info] Resolving a module with a pseudo-conflict
[info] - should work *** FAILED ***
[info]   java.io.IOException: CreateFile() failed with error 3
[info]   at sbt.internal.io.WinMilli$.getHandle(Milli.scala:275)
[info]   at sbt.internal.io.WinMilli$.getModifiedTimeNative(Milli.scala:281)
[info]   at sbt.internal.io.WinMilli$.getModifiedTimeNative(Milli.scala:259)
[info]   at sbt.internal.io.MilliNative.getModifiedTime(Milli.scala:66)
[info]   at sbt.internal.io.Milli$.getModifiedTime(Milli.scala:352)
[info]   at sbt.io.IO$.getModifiedTime(IO.scala:1143)
[info]   at sbt.io.IO$.getModifiedTimeOrZero(IO.scala:1212)
[info]   at sbt.librarymanagement.RichUpdateReport.$anonfun$recomputeStamps$1(RichUpdateReport.scala:23)
[info]   at scala.collection.TraversableLike.$anonfun$map$1(TraversableLike.scala:234)
[info]   at scala.collection.Iterator.foreach(Iterator.scala:929)
[info]   ...
[info] Resolving a module with sbt cross build
[info] - should work *** FAILED ***
[info]   java.io.IOException: CreateFile() failed with error 3
[info]   at sbt.internal.io.WinMilli$.getHandle(Milli.scala:275)
[info]   at sbt.internal.io.WinMilli$.getModifiedTimeNative(Milli.scala:281)
[info]   at sbt.internal.io.WinMilli$.getModifiedTimeNative(Milli.scala:259)
[info]   at sbt.internal.io.MilliNative.getModifiedTime(Milli.scala:66)
[info]   at sbt.internal.io.Milli$.getModifiedTime(Milli.scala:352)
[info]   at sbt.io.IO$.getModifiedTime(IO.scala:1143)
[info]   at sbt.io.IO$.getModifiedTimeOrZero(IO.scala:1212)
[info]   at sbt.librarymanagement.RichUpdateReport.$anonfun$recomputeStamps$1(RichUpdateReport.scala:23)
[info]   at scala.collection.TraversableLike.$anonfun$map$1(TraversableLike.scala:234)
[info]   at scala.collection.Iterator.foreach(Iterator.scala:929)
[info]   ...
```
i'm not sure if it's just me, but they are failing without these changes too