### PR TITLE
Enable sbt to specify -Dconfig.resource=/path/to/configFile without disabling gigahorse

### DIFF
--- a/core/src/main/scala/sbt/librarymanagement/Http.scala
+++ b/core/src/main/scala/sbt/librarymanagement/Http.scala
@@ -3,5 +3,5 @@ package sbt.librarymanagement
 import gigahorse._, support.okhttp.Gigahorse
 
 object Http {
-  lazy val http: HttpClient = Gigahorse.http(Gigahorse.config)
+  lazy val http: HttpClient = Gigahorse.http(gigahorse.Config())
 }

--- a/ivy/src/main/scala/sbt/internal/librarymanagement/ivyint/GigahorseUrlHandler.scala
+++ b/ivy/src/main/scala/sbt/internal/librarymanagement/ivyint/GigahorseUrlHandler.scala
@@ -214,7 +214,7 @@ object GigahorseUrlHandler {
 
   private val EmptyBuffer: Array[Byte] = new Array[Byte](0)
 
-  lazy val http: HttpClient = Gigahorse.http(Gigahorse.config)
+  lazy val http: HttpClient = Gigahorse.http(gigahorse.Config())
 
   private lazy val okHttpClient: OkHttpClient = {
     http


### PR DESCRIPTION
This PR fixes https://github.com/sbt/sbt/issues/3585.

- [As @lunaryorn comments on the issue](https://github.com/sbt/sbt/issues/3585#issuecomment-339602134), the problem is caused by [Gigahorse.config tries to load specified config file in sbt's classpath calling ConfigFactory.load](https://github.com/eed3si9n/gigahorse/blob/4e139e46f2763e4d94d736f2b87e9d67051c9ccf/core/src/main/scala/gigahorse/GigahorseSupport.scala#L35-L42) . And of course fail to find the specified config file, throw `java.io.IOException` if we specify `-Dconfig.resource`.
  - (Otherwise the exception won't be thrown because [lightbend/config tries to find application.(conf|json|properties)](https://github.com/lightbend/config/blob/f6680a5dad51d992139d45a84fad734f1778bf50/config/src/main/java/com/typesafe/config/impl/SimpleIncluder.java#L174-L247) in sbt's classpath with [allowMissing=true](https://github.com/lightbend/config/blob/f6680a5dad51d992139d45a84fad734f1778bf50/config/src/main/java/com/typesafe/config/ConfigParseOptions.java#L30-L47) which suppresses throwing the exception on failing to find the config file.)
- We can avoid trying to load specified config file inside sbt by avoid using `Gigahorse.config`.
- This PR fixes `sbt/librarymanagement` not to use `Gigahorse.config` and make sbt use `gigahorse.Config()` which returns gigahorse's default config without calling `ConfigFactory.load()` instead.

## concerns
- Actually we were able to configure gigahorse inside sbt by `-Dconfig.file=/path/to/configFile` (but I don't think anyone deliberately configure gigahorse in sbt by `-Dconfig.file`) , this PR disable sbt user to configure gigahorse in sbt.
  - Maybe we should add any ways to configure gigahorse in sbt? (like `-Dsbt.gigahorse.config=/path/to/conf/for/gigahorse`