### PR TITLE
Fix flaky OfflineModeSpec

### DIFF
--- a/ivy/src/test/scala/sbt/internal/librarymanagement/OfflineModeSpec.scala
+++ b/ivy/src/test/scala/sbt/internal/librarymanagement/OfflineModeSpec.scala
@@ -2,10 +2,10 @@ package sbt.internal.librarymanagement
 
 import sbt.librarymanagement._
 import sbt.librarymanagement.ivy.UpdateOptions
-import org.scalatest.Assertion
+import org.scalatest.{ Assertion, DiagrammedAssertions }
 import sbt.io.IO
 
-class OfflineModeSpec extends BaseIvySpecification {
+class OfflineModeSpec extends BaseIvySpecification with DiagrammedAssertions {
   private final def targetDir = Some(currentDependency)
   private final def onlineConf = makeUpdateConfiguration(false, targetDir)
   private final def offlineConf = makeUpdateConfiguration(true, targetDir)
@@ -37,18 +37,13 @@ class OfflineModeSpec extends BaseIvySpecification {
     assert(onlineResolution.isRight)
     assert(onlineResolution.right.exists(report => report.stats.resolveTime > 0))
 
-    // Compute an estimate to ensure that the second resolution does indeed use the cache
     val originalResolveTime = onlineResolution.right.get.stats.resolveTime
-    val estimatedCachedTime = originalResolveTime * 0.3
-
     val offlineResolution =
       IvyActions.updateEither(toResolve, offlineConf, warningConf, log)
-    assert(offlineResolution.isRight, s"Offline resolution has failed with $offlineResolution.")
+    assert(offlineResolution.isRight)
 
     val resolveTime = offlineResolution.right.get.stats.resolveTime
-    // Only check the estimate for the non cached resolution, otherwise resolution is cached
-    assert(resolveTime <= estimatedCachedTime,
-           "Offline resolution took more than 15% of normal resolution's running time.")
+    assert(originalResolveTime > resolveTime)
   }
 
   "Offline update configuration" should "reuse the caches when offline is enabled" in {


### PR DESCRIPTION
Fixes https://github.com/sbt/librarymanagement/issues/229

OfflineModeSpec is failing often because it asserts that the offline resolution needs to happen within 30% of the original resolution, and I guess it really depends on the weather how much portion of it spends on resolution.