### PR TITLE
Set Gigahorse readTimeout to 1 hour

### DIFF
--- a/core/src/main/scala/sbt/librarymanagement/Http.scala
+++ b/core/src/main/scala/sbt/librarymanagement/Http.scala
@@ -1,7 +1,8 @@
 package sbt.librarymanagement
 
 import gigahorse._, support.okhttp.Gigahorse
+import scala.concurrent.duration.DurationInt
 
 object Http {
-  lazy val http: HttpClient = Gigahorse.http(gigahorse.Config())
+  lazy val http: HttpClient = Gigahorse.http(gigahorse.Config().withReadTimeout(60.minutes))
 }

--- a/ivy/src/main/scala/sbt/internal/librarymanagement/ivyint/GigahorseUrlHandler.scala
+++ b/ivy/src/main/scala/sbt/internal/librarymanagement/ivyint/GigahorseUrlHandler.scala
@@ -198,8 +198,8 @@ class GigahorseUrlHandler extends AbstractURLHandler {
 
 object GigahorseUrlHandler {
   import gigahorse.HttpClient
-  import gigahorse.support.okhttp.Gigahorse
   import okhttp3.{ OkHttpClient, JavaNetAuthenticator }
+  import sbt.librarymanagement.Http
 
   // This is requires to access the constructor of URLInfo.
   private[sbt] class SbtUrlInfo(available: Boolean,
@@ -214,7 +214,7 @@ object GigahorseUrlHandler {
 
   private val EmptyBuffer: Array[Byte] = new Array[Byte](0)
 
-  lazy val http: HttpClient = Gigahorse.http(gigahorse.Config())
+  lazy val http: HttpClient = Http.http
 
   private lazy val okHttpClient: OkHttpClient = {
     http


### PR DESCRIPTION
Following the suggestion made by @eed3si9n in https://github.com/sbt/sbt/issues/4199:
- Use the `HttpClient` from `core` in `ivy`.
- Configure Gigahorse to use a `readTimeout` of 60 minutes.