### PR TITLE
Scripted integration test infrastructure with Sbt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 tmp/
 target/
 __pycache__
+
+scripted-test/src/sbt-test/*/*/project/build.properties

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,12 @@ language: scala
 jdk: oraclejdk8
 
 scala:
-  - 2.11.12
   - 2.12.7
 
 matrix:
   include:
+  - scala: 2.12.7
+    jdk: oraclejdk8
   - scala: 2.12.7
     jdk: openjdk11
 
@@ -16,6 +17,7 @@ script: sbt -Dfile.encoding=UTF8 -J-XX:ReservedCodeCacheSize=256M
   scalafmt::test test:scalafmt::test sbt:scalafmt::test
   whitesourceCheckPolicies
   test
+  scriptedIvy
   packagedArtifacts # ensure that all artifacts for publish package without failure
 
 env:
@@ -28,5 +30,7 @@ cache:
     - $HOME/.sbt
 
 before_cache:
+  # - find $HOME/.ivy2/local -name "*-LM-SNAPSHOT*" -exec rm -r "{}" \;
+  - find $HOME/.ivy2/cache -name "*-LM-SNAPSHOT*" -delete
   - find $HOME/.ivy2/cache -name "ivydata-*.properties" -delete
   - find $HOME/.sbt        -name "*.lock"               -delete

--- a/build.sbt
+++ b/build.sbt
@@ -259,6 +259,26 @@ lazy val lmIvy = (project in file("ivy"))
     ),
   )
 
+lazy val lmScriptedTest = (project in file("scripted-test"))
+  .enablePlugins(SbtPlugin)
+  .settings(
+    commonSettings,
+    skip in publish := true,
+    name := "scripted-test",
+    scriptedLaunchOpts := { scriptedLaunchOpts.value ++
+      Seq("-Xmx1024M", "-Dplugin.version=" + version.value)
+    },
+    scriptedBufferLog := false
+  ).enablePlugins(SbtScriptedIT)
+
+addCommandAlias("scriptedIvy", Seq(
+  "lmCore/publishLocal",
+  "lmIvy/publishLocal",
+  "lmScriptedTest/clean",
+  """set ThisBuild / scriptedTestLMImpl := "ivy"""",
+  """set ThisBuild / scriptedLaunchOpts += "-Ddependency.resolution=set ThisBuild / dependencyResolution := sbt.librarymanagement.ivy.IvyDependencyResolution(ivyConfiguration.value)" """,
+  "lmScriptedTest/scripted").mkString(";",";",""))
+
 def customCommands: Seq[Setting[_]] = Seq(
   commands += Command.command("release") { state =>
     // "clean" ::

--- a/project/SbtScriptedIT.scala
+++ b/project/SbtScriptedIT.scala
@@ -1,0 +1,106 @@
+import sbt._
+import Keys._
+
+import java.io.File
+import java.util.UUID.randomUUID
+
+object SbtScriptedIT extends AutoPlugin {
+
+  object autoImport {
+    val scriptedTestSbtRepo = settingKey[String]("SBT repository to be used in scripted tests")
+    val scriptedTestSbtRef = settingKey[String]("SBT branch to be used in scripted tests")
+    val scriptedTestLMImpl = settingKey[String]("Librarymanagement implementation to be used in scripted tests")
+    val scriptedSbtVersion = settingKey[String]("SBT version to be published locally for IT tests")
+  }
+
+  import autoImport._
+  override def requires = ScriptedPlugin
+
+  override def trigger = noTrigger
+
+  override lazy val globalSettings = Seq(
+    scriptedTestSbtRepo := "https://github.com/sbt/sbt.git",
+    scriptedTestSbtRef := "develop",
+    scriptedTestLMImpl := "ivy",
+    scriptedSbtVersion := s"""${sbtVersion.value}-LM-SNAPSHOT"""
+  )
+
+  private def cloneSbt(targetDir: File, repo: String, ref: String) = {
+    import org.eclipse.jgit.api._
+
+    if (!targetDir.exists) {
+      IO.createDirectory(targetDir)
+
+      new CloneCommand()
+        .setDirectory(targetDir)
+        .setURI(repo)
+        .call()
+
+      val git = Git.open(targetDir)
+
+      git.checkout().setName(ref).call()
+    }
+  }
+
+  private def publishLocalSbt(
+      targetDir: File,
+      lmVersion: String,
+      lmGroupID: String,
+      lmArtifactID: String,
+      version: String) = {
+    import sys.process._
+    Process(
+      Seq(
+        "sbt",
+        "-J-Xms2048m",
+        "-J-Xmx2048m",
+        "-J-XX:ReservedCodeCacheSize=256m",
+        "-J-XX:MaxMetaspaceSize=512m",
+        s"""-Dsbt.build.lm.version=${lmVersion}""",
+        s"""-Dsbt.build.lm.organization=${lmGroupID}""",
+        s"""-Dsbt.build.lm.moduleName=${lmArtifactID}""",
+        s"""set ThisBuild / version := "${version}"""",
+        "clean",
+        "publishLocal"
+      ),
+      Some(targetDir)
+    ) !
+  }
+
+  private def setScriptedTestsSbtVersion(baseDir: File, version: String) = {
+    IO.listFiles(baseDir).foreach { d =>
+      if (d.isDirectory) {
+        IO.createDirectory(d / "project")
+        IO.write(
+          d / "project" / "build.properties",
+          s"sbt.version=$version"
+        )
+      }
+    }
+  }
+
+  import sbt.ScriptedPlugin.autoImport._
+
+  override lazy val projectSettings = Seq(
+    scriptedTests := {
+      val targetDir = target.value / "sbt"
+
+      cloneSbt(targetDir, scriptedTestSbtRepo.value, scriptedTestSbtRef.value)
+
+      publishLocalSbt(
+        targetDir,
+        version.value,
+        organization.value,
+        s"librarymanagement-${scriptedTestLMImpl.value}",
+        scriptedSbtVersion.value
+      )
+
+      setScriptedTestsSbtVersion(
+        sbtTestDirectory.value / thisProject.value.id,
+        scriptedSbtVersion.value
+      )
+
+      scriptedTests.value
+    }
+  )
+}

--- a/scripted-test/src/sbt-test/lmScriptedTest/simple/Main.scala
+++ b/scripted-test/src/sbt-test/lmScriptedTest/simple/Main.scala
@@ -1,0 +1,8 @@
+
+object Main {
+
+  import com.typesafe.config.ConfigFactory
+
+  val x = ConfigFactory.load()
+
+}

--- a/scripted-test/src/sbt-test/lmScriptedTest/simple/build.sbt
+++ b/scripted-test/src/sbt-test/lmScriptedTest/simple/build.sbt
@@ -1,0 +1,8 @@
+
+addCommandAlias("setDependencyResolution", sys.props.get("dependency.resolution") match {
+  case Some(x) => x
+  case _ => sys.error("""|The system property 'dependency.resolution' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+})
+
+libraryDependencies += "com.typesafe" % "config" % "1.3.2"

--- a/scripted-test/src/sbt-test/lmScriptedTest/simple/test
+++ b/scripted-test/src/sbt-test/lmScriptedTest/simple/test
@@ -1,0 +1,5 @@
+> sbtVersion
+> setDependencyResolution
+> show ThisBuild/dependencyResolution
+> clean
+> compile


### PR DESCRIPTION
This PR contains a basic infrastructure for integration tests of this library with Sbt itself.
I consider this solution strictly better than a bash script since is ways more portable and maintainable.

Here you have the negative test that fail in case of problems with the code (if not cached early).
https://travis-ci.org/andreaTP/librarymanagement/jobs/436603053#L1146
from this branch: https://github.com/andreaTP/librarymanagement/blob/negativeTest

This will make implementing and testing an alternative implementation of `librarymanagement` much easier.

cc. @leonardehrenfried @eed3si9n @alexarchambault