### PR TITLE
Collapse eviction warnings

### DIFF
--- a/core/src/main/scala/sbt/librarymanagement/EvictionWarning.scala
+++ b/core/src/main/scala/sbt/librarymanagement/EvictionWarning.scala
@@ -314,8 +314,8 @@ object EvictionWarning {
   implicit val evictionWarningLines: ShowLines[EvictionWarning] = ShowLines { a: EvictionWarning =>
     import ShowLines._
     val out: mutable.ListBuffer[String] = mutable.ListBuffer()
-    if (a.options.warnEvictionSummary && a.allEvictions.nonEmpty) {
-      out += "There may be incompatibilities among your library dependencies."
+    if ((a.options.warnEvictionSummary || a.reportedEvictions.nonEmpty) && a.allEvictions.nonEmpty) {
+      out += "There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings."
     }
 
     if (a.scalaEvictions.nonEmpty) {
@@ -330,10 +330,6 @@ object EvictionWarning {
       out += ""
       out ++= (a.directEvictions flatMap { _.lines })
       out ++= (a.transitiveEvictions flatMap { _.lines })
-    }
-
-    if (a.allEvictions.nonEmpty && (a.options.warnEvictionSummary || a.reportedEvictions.nonEmpty)) {
-      out += "Run 'evicted' to see detailed eviction warnings"
     }
 
     out.toList

--- a/ivy/src/test/scala/sbt/internal/librarymanagement/EvictionWarningSpec.scala
+++ b/ivy/src/test/scala/sbt/internal/librarymanagement/EvictionWarningSpec.scala
@@ -116,7 +116,7 @@ class EvictionWarningSpec extends BaseIvySpecification {
         "\t* org.scala-lang:scala-library:2.10.3 is selected over 2.10.2",
         "",
         "To force scalaVersion, add the following:",
-        "\tscalaModuleInfo ~= (_.map(_.withOverrideScalaVersion(true)))",
+        "\tscalaModuleInfo ~= (_.map(_.withOverrideScalaVersion(true)))"
       )
   }
 
@@ -132,7 +132,7 @@ class EvictionWarningSpec extends BaseIvySpecification {
         "\t    +- com.example:foo:0.1.0                              (depends on 2.10.2)",
         "",
         "To force scalaVersion, add the following:",
-        "\tscalaModuleInfo ~= (_.map(_.withOverrideScalaVersion(true)))",
+        "\tscalaModuleInfo ~= (_.map(_.withOverrideScalaVersion(true)))"
       )
   }
 
@@ -141,7 +141,7 @@ class EvictionWarningSpec extends BaseIvySpecification {
     val report = ivyUpdate(m)
     EvictionWarning(m, EvictionWarningOptions.summary, report).lines shouldBe
       List(
-        "There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.",
+        "There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings."
       )
   }
 
@@ -187,7 +187,7 @@ class EvictionWarningSpec extends BaseIvySpecification {
         "",
         "\t* commons-io:commons-io:2.4 is selected over 1.4",
         "\t    +- com.example:foo:0.1.0                              (depends on 1.4)",
-        "",
+        ""
       )
   }
 
@@ -201,7 +201,7 @@ class EvictionWarningSpec extends BaseIvySpecification {
         "",
         "\t* commons-io:commons-io:2.4 is selected over 1.4",
         "\t    +- com.example:foo:0.1.0                              (depends on 1.4)",
-        "",
+        ""
       )
   }
 
@@ -210,7 +210,7 @@ class EvictionWarningSpec extends BaseIvySpecification {
     val report = ivyUpdate(m)
     EvictionWarning(m, EvictionWarningOptions.summary, report).lines shouldBe
       List(
-        "There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.",
+        "There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings."
       )
   }
 
@@ -265,7 +265,7 @@ class EvictionWarningSpec extends BaseIvySpecification {
         "",
         "\t* com.typesafe.akka:akka-actor_2.10:2.3.4 is selected over 2.1.4",
         "\t    +- com.example:foo:0.1.0                              (depends on 2.1.4)",
-        "",
+        ""
       )
   }
 
@@ -275,7 +275,7 @@ class EvictionWarningSpec extends BaseIvySpecification {
     val report = ivyUpdate(m)
     EvictionWarning(m, EvictionWarningOptions.summary, report).lines shouldBe
       List(
-        "There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.",
+        "There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings."
       )
   }
 
@@ -313,7 +313,7 @@ class EvictionWarningSpec extends BaseIvySpecification {
         "\t    +- com.typesafe.akka:akka-remote_2.10:2.3.4           (depends on 2.3.4)",
         "\t    +- org.w3:banana-rdf_2.10:0.4                         (depends on 2.1.4)",
         "\t    +- org.w3:banana-sesame_2.10:0.4                      (depends on 2.1.4)",
-        "",
+        ""
       )
   }
 
@@ -322,7 +322,7 @@ class EvictionWarningSpec extends BaseIvySpecification {
     val report = ivyUpdate(m)
     EvictionWarning(m, EvictionWarningOptions.summary, report).lines shouldBe
       List(
-        "There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.",
+        "There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings."
       )
   }
 

--- a/ivy/src/test/scala/sbt/internal/librarymanagement/EvictionWarningSpec.scala
+++ b/ivy/src/test/scala/sbt/internal/librarymanagement/EvictionWarningSpec.scala
@@ -111,12 +111,12 @@ class EvictionWarningSpec extends BaseIvySpecification {
     val report = ivyUpdate(m)
     EvictionWarning(m, fullOptions.withShowCallers(false), report).lines shouldBe
       List(
+        "There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.",
         "Scala version was updated by one of library dependencies:",
         "\t* org.scala-lang:scala-library:2.10.3 is selected over 2.10.2",
         "",
         "To force scalaVersion, add the following:",
         "\tscalaModuleInfo ~= (_.map(_.withOverrideScalaVersion(true)))",
-        "Run 'evicted' to see detailed eviction warnings"
       )
   }
 
@@ -125,6 +125,7 @@ class EvictionWarningSpec extends BaseIvySpecification {
     val report = ivyUpdate(m)
     EvictionWarning(m, fullOptions, report).lines shouldBe
       List(
+        "There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.",
         "Scala version was updated by one of library dependencies:",
         "\t* org.scala-lang:scala-library:2.10.3 is selected over 2.10.2",
         "\t    +- com.typesafe.akka:akka-actor_2.10:2.3.0            (depends on 2.10.3)",
@@ -132,7 +133,6 @@ class EvictionWarningSpec extends BaseIvySpecification {
         "",
         "To force scalaVersion, add the following:",
         "\tscalaModuleInfo ~= (_.map(_.withOverrideScalaVersion(true)))",
-        "Run 'evicted' to see detailed eviction warnings"
       )
   }
 
@@ -141,8 +141,7 @@ class EvictionWarningSpec extends BaseIvySpecification {
     val report = ivyUpdate(m)
     EvictionWarning(m, EvictionWarningOptions.summary, report).lines shouldBe
       List(
-        "There may be incompatibilities among your library dependencies.",
-        "Run 'evicted' to see detailed eviction warnings"
+        "There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.",
       )
   }
 
@@ -183,12 +182,12 @@ class EvictionWarningSpec extends BaseIvySpecification {
     val report = ivyUpdate(m)
     EvictionWarning(m, fullOptions, report).lines shouldBe
       List(
+        "There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.",
         "Found version conflict(s) in library dependencies; some are suspected to be binary incompatible:",
         "",
         "\t* commons-io:commons-io:2.4 is selected over 1.4",
         "\t    +- com.example:foo:0.1.0                              (depends on 1.4)",
         "",
-        "Run 'evicted' to see detailed eviction warnings"
       )
   }
 
@@ -197,12 +196,12 @@ class EvictionWarningSpec extends BaseIvySpecification {
     val report = ivyUpdate(m)
     EvictionWarning(m, fullOptions.withShowCallers(true), report).lines shouldBe
       List(
+        "There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.",
         "Found version conflict(s) in library dependencies; some are suspected to be binary incompatible:",
         "",
         "\t* commons-io:commons-io:2.4 is selected over 1.4",
         "\t    +- com.example:foo:0.1.0                              (depends on 1.4)",
         "",
-        "Run 'evicted' to see detailed eviction warnings"
       )
   }
 
@@ -211,8 +210,7 @@ class EvictionWarningSpec extends BaseIvySpecification {
     val report = ivyUpdate(m)
     EvictionWarning(m, EvictionWarningOptions.summary, report).lines shouldBe
       List(
-        "There may be incompatibilities among your library dependencies.",
-        "Run 'evicted' to see detailed eviction warnings"
+        "There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.",
       )
   }
 
@@ -243,7 +241,7 @@ class EvictionWarningSpec extends BaseIvySpecification {
     val report = ivyUpdate(m)
     EvictionWarning(m, fullOptions, report).lines shouldBe
       List(
-        "There may be incompatibilities among your library dependencies.",
+        "There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.",
         "Here are some of the libraries that were evicted:",
         "\t* commons-io:commons-io:1.4 -> 2.4 (caller: ca.gobits.bnf:bnfparser:1.0, net.databinder:unfiltered-uploads_2.10:0.8.0)"
       )
@@ -262,12 +260,12 @@ class EvictionWarningSpec extends BaseIvySpecification {
     val report = ivyUpdate(m)
     EvictionWarning(m, fullOptions, report).lines shouldBe
       List(
+        "There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.",
         "Found version conflict(s) in library dependencies; some are suspected to be binary incompatible:",
         "",
         "\t* com.typesafe.akka:akka-actor_2.10:2.3.4 is selected over 2.1.4",
         "\t    +- com.example:foo:0.1.0                              (depends on 2.1.4)",
         "",
-        "Run 'evicted' to see detailed eviction warnings"
       )
   }
 
@@ -277,8 +275,7 @@ class EvictionWarningSpec extends BaseIvySpecification {
     val report = ivyUpdate(m)
     EvictionWarning(m, EvictionWarningOptions.summary, report).lines shouldBe
       List(
-        "There may be incompatibilities among your library dependencies.",
-        "Run 'evicted' to see detailed eviction warnings"
+        "There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.",
       )
   }
 
@@ -309,6 +306,7 @@ class EvictionWarningSpec extends BaseIvySpecification {
     val report = ivyUpdate(m)
     EvictionWarning(m, fullOptions, report).lines shouldBe
       List(
+        "There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.",
         "Found version conflict(s) in library dependencies; some are suspected to be binary incompatible:",
         "",
         "\t* com.typesafe.akka:akka-actor_2.10:2.3.4 is selected over 2.1.4",
@@ -316,7 +314,6 @@ class EvictionWarningSpec extends BaseIvySpecification {
         "\t    +- org.w3:banana-rdf_2.10:0.4                         (depends on 2.1.4)",
         "\t    +- org.w3:banana-sesame_2.10:0.4                      (depends on 2.1.4)",
         "",
-        "Run 'evicted' to see detailed eviction warnings"
       )
   }
 
@@ -325,8 +322,7 @@ class EvictionWarningSpec extends BaseIvySpecification {
     val report = ivyUpdate(m)
     EvictionWarning(m, EvictionWarningOptions.summary, report).lines shouldBe
       List(
-        "There may be incompatibilities among your library dependencies.",
-        "Run 'evicted' to see detailed eviction warnings"
+        "There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.",
       )
   }
 


### PR DESCRIPTION
Rather than

    [warn] There may be incompatibilities among your library dependencies.
    [warn] Run 'evicted' to see detailed eviction warnings
    [info] Done updating.
    [warn] There may be incompatibilities among your library dependencies.
    [warn] Run 'evicted' to see detailed eviction warnings
    [info] Done updating.
    [warn] There may be incompatibilities among your library dependencies.
    [warn] Run 'evicted' to see detailed eviction warnings
    [info] Done updating.
    [warn] There may be incompatibilities among your library dependencies.
    [warn] Run 'evicted' to see detailed eviction warnings

I would get:

    [warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings
    [info] Done updating.
    [warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings
    [info] Done updating.
    [warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings
    [info] Done updating.
    [warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings

which is a touch better. (IMO!)