### PR TITLE
[1.2.x] Use fixed thread pool

### DIFF
--- a/ivy/src/main/scala/sbt/internal/librarymanagement/ivyint/ParallelResolveEngine.scala
+++ b/ivy/src/main/scala/sbt/internal/librarymanagement/ivyint/ParallelResolveEngine.scala
@@ -19,8 +19,12 @@ private[ivyint] case class DownloadResult(dep: IvyNode,
                                           totalSizeDownloaded: Long)
 
 object ParallelResolveEngine {
-  private val resolveExecutionContext =
-    ExecutionContext.fromExecutor(Executors.newCachedThreadPool())
+  private lazy val resolveExecutionContext: ExecutionContext = {
+    // This throttles the connection number, especially when Gigahorse is not used.
+    val maxConnectionCount = 6
+    val executor = Executors.newFixedThreadPool(maxConnectionCount)
+    ExecutionContext.fromExecutor(executor)
+  }
 }
 
 /** Define an ivy [[ResolveEngine]] that resolves dependencies in parallel. */


### PR DESCRIPTION
This is a backport of #278 
Fixes #274

In #249 parallel download switched to using its own thread pool.
It could potentially lead to unbounded download if nobody throttled.
This works around the issue by fixing the number of thread to 6, which is a common per-host max connection count.