### PR TITLE
Enable Gigahorse configuration

### DIFF
--- a/core/src/main/scala/sbt/librarymanagement/Http.scala
+++ b/core/src/main/scala/sbt/librarymanagement/Http.scala
@@ -4,5 +4,5 @@ import gigahorse._, support.okhttp.Gigahorse
 import scala.concurrent.duration.DurationInt
 
 object Http {
-  lazy val http: HttpClient = Gigahorse.http(gigahorse.Config().withReadTimeout(60.minutes))
+  lazy val http: HttpClient = Gigahorse.http(Gigahorse.config.withReadTimeout(60.minutes))
 }


### PR DESCRIPTION
This allows using `application.conf` if present, where Gigahorse configuration might be defined, see: http://eed3si9n.com/gigahorse/configuration.html#Configuring+Gigahorse