### PR TITLE
make object Disabled extend Disabled

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -157,13 +157,6 @@ lazy val lmCore = (project in file("core"))
       exclude[DirectMissingMethodProblem]("sbt.librarymanagement.ArtifactExtra.extension"),
       exclude[DirectMissingMethodProblem]("sbt.librarymanagement.ArtifactTypeFilterExtra.types"),
 
-      // by mistake we aliased the companion object instead of an instance of Disabled
-      // but it was aliased as a constant expression, so even if the binary API has changed
-      // there are no call sites in bytecode because the value got inlined
-      // also it's wouldn't work so I doubt anyone has made use of it
-      exclude[DirectMissingMethodProblem]("sbt.librarymanagement.CrossVersionFunctions.Disabled"),
-      exclude[IncompatibleResultTypeProblem]("sbt.librarymanagement.CrossVersionFunctions.Disabled"),
-
       // contraband issue
       exclude[DirectMissingMethodProblem]("sbt.internal.librarymanagement.ConfigurationReportLite.copy*"),
       exclude[DirectMissingMethodProblem]("sbt.internal.librarymanagement.UpdateReportLite.copy*"),

--- a/core/src/main/contraband-scala/sbt/librarymanagement/Disabled.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/Disabled.scala
@@ -5,7 +5,7 @@
 // DO NOT EDIT MANUALLY
 package sbt.librarymanagement
 /** Disables cross versioning for a module. */
-final class Disabled private () extends sbt.librarymanagement.CrossVersion() with Serializable {
+sealed class Disabled private () extends sbt.librarymanagement.CrossVersion() with Serializable {
 
 
 
@@ -24,7 +24,7 @@ private[this] def copy(): Disabled = {
 }
 
 }
-object Disabled {
+object Disabled extends sbt.librarymanagement.Disabled {
   
   def apply(): Disabled = new Disabled()
 }

--- a/core/src/main/contraband/librarymanagement.json
+++ b/core/src/main/contraband/librarymanagement.json
@@ -261,7 +261,9 @@
           "namespace": "sbt.librarymanagement",
           "target": "Scala",
           "doc": "Disables cross versioning for a module.",
-          "type": "record"
+          "type": "record",
+          "modifier": "sealed",
+          "parentsCompanion": "sbt.librarymanagement.Disabled"
         },
         {
           "name": "Binary",

--- a/core/src/main/scala/sbt/librarymanagement/CrossVersionExtra.scala
+++ b/core/src/main/scala/sbt/librarymanagement/CrossVersionExtra.scala
@@ -8,7 +8,7 @@ final case class ScalaVersion(full: String, binary: String)
 private[librarymanagement] abstract class CrossVersionFunctions {
 
   /** Compatibility with 0.13 */
-  final val Disabled = sbt.librarymanagement.Disabled()
+  final def Disabled = sbt.librarymanagement.Disabled
   final val Binary = sbt.librarymanagement.Binary
   final val Constant = sbt.librarymanagement.Constant
   final val Full = sbt.librarymanagement.Full

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("org.scala-sbt"  % "sbt-houserules"  % "0.3.8")
 addSbtPlugin("com.lucidchart" % "sbt-scalafmt"    % "1.15")
-addSbtPlugin("org.scala-sbt"  % "sbt-contraband"  % "0.4.1")
+addSbtPlugin("org.scala-sbt"  % "sbt-contraband"  % "0.4.2")
 addSbtPlugin("com.lightbend"  % "sbt-whitesource" % "0.1.9")
 
 scalacOptions += "-language:postfixOps"


### PR DESCRIPTION
Ref https://github.com/sbt/librarymanagement/pull/280
Ref https://github.com/sbt/contraband/pull/127

This is to workaround bincompat error detected by sbt community build.

```
[cats] [error] java.lang.NoSuchMethodError: sbt.librarymanagement.CrossVersion$.Disabled()Lsbt/librarymanagement/Disabled$;
```