### PR TITLE
Deprecate CrossVersion.Disabled (was make CrossVersion.Disabled stable)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -100,6 +100,10 @@ lazy val lmCore = (project in file("core"))
       scalaCheck % Test,
       scalaVerify % Test,
     ),
+    libraryDependencies ++= (scalaVersion.value match {
+      case v if v.startsWith("2.12.") => List(compilerPlugin(silencerPlugin))
+      case _                          => List()
+    }),
     libraryDependencies += scalaXml,
     resourceGenerators in Compile += Def
       .task(

--- a/core/src/main/scala/sbt/librarymanagement/CrossVersion.scala
+++ b/core/src/main/scala/sbt/librarymanagement/CrossVersion.scala
@@ -39,7 +39,7 @@ sealed class Disabled private () extends sbt.librarymanagement.CrossVersion() wi
 
 }
 object Disabled extends sbt.librarymanagement.Disabled {
-  def apply(): Disabled = new Disabled()
+  def apply(): Disabled = Disabled
 }
 
 /**

--- a/core/src/main/scala/sbt/librarymanagement/CrossVersionExtra.scala
+++ b/core/src/main/scala/sbt/librarymanagement/CrossVersionExtra.scala
@@ -8,7 +8,7 @@ final case class ScalaVersion(full: String, binary: String)
 private[librarymanagement] abstract class CrossVersionFunctions {
 
   /** Compatibility with 0.13 */
-  final def Disabled = sbt.librarymanagement.Disabled
+  final val Disabled = sbt.librarymanagement.Disabled
   final val Binary = sbt.librarymanagement.Binary
   final val Constant = sbt.librarymanagement.Constant
   final val Full = sbt.librarymanagement.Full

--- a/core/src/main/scala/sbt/librarymanagement/CrossVersionExtra.scala
+++ b/core/src/main/scala/sbt/librarymanagement/CrossVersionExtra.scala
@@ -8,6 +8,10 @@ final case class ScalaVersion(full: String, binary: String)
 private[librarymanagement] abstract class CrossVersionFunctions {
 
   /** Compatibility with 0.13 */
+  @deprecated(
+    "use CrossVersion.disabled instead. prior to sbt 1.3.0, Diabled did not work without apply(). sbt/sbt#4977",
+    "1.3.0"
+  )
   final val Disabled = sbt.librarymanagement.Disabled
   final val Binary = sbt.librarymanagement.Binary
   final val Constant = sbt.librarymanagement.Constant
@@ -37,7 +41,7 @@ private[librarymanagement] abstract class CrossVersionFunctions {
   def binary: CrossVersion = Binary()
 
   /** Disables cross versioning for a module. */
-  def disabled: CrossVersion = Disabled
+  def disabled: CrossVersion = sbt.librarymanagement.Disabled
 
   /** Cross-versions a module with a constant string (typically the binary Scala version).  */
   def constant(value: String): CrossVersion = Constant(value)

--- a/core/src/test/scala/example/tests/CrossVersionCompatTest.scala
+++ b/core/src/test/scala/example/tests/CrossVersionCompatTest.scala
@@ -1,0 +1,70 @@
+package example.tests
+
+import sbt.librarymanagement.{ CrossVersion, Disabled }
+import verify.BasicTestSuite
+
+object CrossVersionCompatTest extends BasicTestSuite {
+  test("CrossVersion.Disabled is typed to be Disabled") {
+    assert(CrossVersion.Disabled match {
+      case _: Disabled => true
+      case _           => false
+    })
+  }
+
+  test("CrossVersion.Disabled functions as disabled") {
+    assert(CrossVersion(CrossVersion.disabled, "1.0.0", "1.0") == None)
+    assert(CrossVersion(CrossVersion.Disabled, "1.0.0", "1.0") == None)
+  }
+
+  test("CrossVersion.Disabled() is typed to be Disabled") {
+    assert(CrossVersion.Disabled() match {
+      case _: Disabled => true
+      case _           => false
+    })
+  }
+
+  test("CrossVersion.Disabled() functions as disabled") {
+    assert(CrossVersion(CrossVersion.disabled, "1.0.0", "1.0") == None)
+    assert(CrossVersion(CrossVersion.Disabled(), "1.0.0", "1.0") == None)
+  }
+
+  test("CrossVersion.Disabled is stable") {
+    assert(CrossVersion.Disabled match {
+      case CrossVersion.Disabled => true
+      case _                     => false
+    })
+  }
+
+  test("sbt.librarymanagement.Disabled is typed to be Disabled") {
+    assert(Disabled match {
+      case _: Disabled => true
+      case _           => false
+    })
+  }
+
+  test("sbt.librarymanagement.Disabled is stable") {
+    assert(Disabled match {
+      case Disabled => true
+      case _        => false
+    })
+  }
+
+  test("sbt.librarymanagement.Disabled() is typed to be Disabled") {
+    assert(Disabled() match {
+      case _: Disabled => true
+      case _           => false
+    })
+  }
+
+  test("CrossVersion.disabled is sbt.librarymanagement.Disabled") {
+    assert(CrossVersion.disabled == Disabled)
+  }
+
+  test("CrossVersion.Disabled is sbt.librarymanagement.Disabled") {
+    assert(CrossVersion.Disabled == Disabled)
+  }
+
+  test("CrossVersion.Disabled() is sbt.librarymanagement.Disabled") {
+    assert(CrossVersion.Disabled() == Disabled)
+  }
+}

--- a/core/src/test/scala/example/tests/CrossVersionCompatTest.scala
+++ b/core/src/test/scala/example/tests/CrossVersionCompatTest.scala
@@ -2,7 +2,9 @@ package example.tests
 
 import sbt.librarymanagement.{ CrossVersion, Disabled }
 import verify.BasicTestSuite
+import com.github.ghik.silencer.silent
 
+@silent
 object CrossVersionCompatTest extends BasicTestSuite {
   test("CrossVersion.Disabled is typed to be Disabled") {
     assert(CrossVersion.Disabled match {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -61,4 +61,5 @@ object Dependencies {
   }
   val gigahorseOkhttp = "com.eed3si9n" %% "gigahorse-okhttp" % "0.5.0"
   val okhttpUrlconnection = "com.squareup.okhttp3" % "okhttp-urlconnection" % "3.7.0"
+  val silencerPlugin = "com.github.ghik" %% "silencer-plugin" % "1.4.1"
 }


### PR DESCRIPTION
## migration note

`CrossVersion.Disabled` did not work as expected in sbt 1.0.x ~ 1.2.x.

We recommend using `CrossVersion.disabled` instead. For pattern matching, you can either check equality with `CrossVersion.disabled` or type match with `case _: sbt.librarymanagement.Disabled`.

## original PR

Fixes https://github.com/sbt/sbt/issues/4975
Fixes https://github.com/sbt/sbt/issues/4977

This makes `CrossVersion.Disabled` a stable identifier by reverting `final def` back to `final val`.

This is to fix Scala.JS build

```
[error] ScalaJSCrossVersion.scala:34:23: stable identifier required, but sbt.`package`.CrossVersion.Disabled found.
[error]     case CrossVersion.Disabled =>
[error]                       ^
[error] one error found
[error] (Compile / compileIncremental) Compilation failed
```

### notes

- #121 added `final val Disabled = sbt.librarymanagement.Disabled` but it was just a companion object
- (only available in 1.3.0-x) #280 actually made it `final val Disabled = sbt.librarymanagement.Disabled()`, but this broke Cat's build that was calling `CrossVersion.Disabled()`
- #290 changed to `final def Disabled = sbt.librarymanagement.Disabled` and `object Disabled extends sbt.librarymanagement.Disabled`
- This changes back to `final val Disabled = sbt.librarymanagement.Disabled` (but because we changed the companion object in #290 that's ok)