### PR TITLE
Flip the default to not use Gigahorse by default 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,9 @@ def commonSettings: Seq[Setting[_]] = Def.settings(
       case _                           => old ++ List("-Ywarn-unused", "-Ywarn-unused-import", "-YdisableFlatCpCaching")
     }
   },
-  inCompileAndTest(scalacOptions in console --= Vector("-Ywarn-unused-import", "-Ywarn-unused", "-Xlint")),
+  inCompileAndTest(
+    scalacOptions in console --= Vector("-Ywarn-unused-import", "-Ywarn-unused", "-Xlint")
+  ),
   scalafmtOnCompile := true,
   Test / scalafmtOnCompile := true,
   publishArtifact in Compile := true,
@@ -52,13 +54,22 @@ def commonSettings: Seq[Setting[_]] = Def.settings(
 
 val mimaSettings = Def settings (
   mimaPreviousArtifacts := Set(
-    "1.0.0", "1.0.1", "1.0.2", "1.0.3", "1.0.4",
-    "1.1.0", "1.1.1", "1.1.2", "1.1.3", "1.1.4",
+    "1.0.0",
+    "1.0.1",
+    "1.0.2",
+    "1.0.3",
+    "1.0.4",
+    "1.1.0",
+    "1.1.1",
+    "1.1.2",
+    "1.1.3",
+    "1.1.4",
     "1.2.0",
-  ) map (version =>
-    organization.value %% moduleName.value % version
-      cross (if (crossPaths.value) CrossVersion.binary else CrossVersion.disabled)
-  ),
+  ) map (
+      version =>
+        organization.value %% moduleName.value % version
+          cross (if (crossPaths.value) CrossVersion.binary else CrossVersion.disabled)
+    ),
 )
 
 lazy val lmRoot = (project in file("."))
@@ -73,7 +84,8 @@ lazy val lmRoot = (project in file("."))
           Some(ScmInfo(url(s"https://github.com/$slug"), s"git@github.com:$slug.git"))
         },
         bintrayPackage := "librarymanagement",
-      )),
+      )
+    ),
     commonSettings,
     name := "LM Root",
     publish := {},
@@ -134,33 +146,32 @@ lazy val lmCore = (project in file("core"))
     mimaBinaryIssueFilters ++= Seq(
       exclude[DirectMissingMethodProblem]("sbt.librarymanagement.EvictionWarningOptions.this"),
       exclude[DirectMissingMethodProblem]("sbt.librarymanagement.EvictionWarningOptions.copy"),
-      exclude[IncompatibleResultTypeProblem]("sbt.librarymanagement.EvictionWarningOptions.copy$default$7"),
-
+      exclude[IncompatibleResultTypeProblem](
+        "sbt.librarymanagement.EvictionWarningOptions.copy$default$7"
+      ),
       // internal class moved
       exclude[MissingClassProblem]("sbt.internal.librarymanagement.InlineConfigurationFunctions"),
       // dropped internal class parent (InlineConfigurationFunctions)
       exclude[MissingTypesProblem]("sbt.librarymanagement.ModuleDescriptorConfiguration$"),
-
       // Configuration's copy method was never meant to be public
       exclude[DirectMissingMethodProblem]("sbt.librarymanagement.Configuration.copy"),
       exclude[DirectMissingMethodProblem]("sbt.librarymanagement.Configuration.copy$default$*"),
-
       // the data type copy methods were never meant to be public
       exclude[DirectMissingMethodProblem]("sbt.librarymanagement.ArtifactExtra.copy"),
       exclude[DirectMissingMethodProblem]("sbt.librarymanagement.ArtifactExtra.copy$default$*"),
       exclude[DirectMissingMethodProblem]("sbt.librarymanagement.ModuleReportExtra.copy"),
       exclude[DirectMissingMethodProblem]("sbt.librarymanagement.ModuleReportExtra.copy$default$*"),
       exclude[DirectMissingMethodProblem]("sbt.librarymanagement.ArtifactTypeFilterExtra.copy"),
-      exclude[DirectMissingMethodProblem]("sbt.librarymanagement.ArtifactTypeFilterExtra.copy$default$*"),
+      exclude[DirectMissingMethodProblem](
+        "sbt.librarymanagement.ArtifactTypeFilterExtra.copy$default$*"
+      ),
       exclude[DirectMissingMethodProblem]("sbt.librarymanagement.ModuleIDExtra.copy"),
       exclude[DirectMissingMethodProblem]("sbt.librarymanagement.ModuleIDExtra.copy$default$*"),
-
       // these abstract classes are private[librarymanagement] so it's fine if they have more methods
       exclude[ReversedMissingMethodProblem]("sbt.librarymanagement.ArtifactExtra.*"),
       exclude[ReversedMissingMethodProblem]("sbt.librarymanagement.ModuleReportExtra.*"),
       exclude[ReversedMissingMethodProblem]("sbt.librarymanagement.ArtifactTypeFilterExtra.*"),
       exclude[ReversedMissingMethodProblem]("sbt.librarymanagement.ModuleIDExtra.*"),
-
       // these abstract classes are private[librarymanagement] so they can lose these abstract methods
       exclude[DirectMissingMethodProblem]("sbt.librarymanagement.ArtifactExtra.type"),
       exclude[DirectMissingMethodProblem]("sbt.librarymanagement.ArtifactExtra.url"),
@@ -170,9 +181,10 @@ lazy val lmCore = (project in file("core"))
       exclude[DirectMissingMethodProblem]("sbt.librarymanagement.ArtifactExtra.classifier"),
       exclude[DirectMissingMethodProblem]("sbt.librarymanagement.ArtifactExtra.extension"),
       exclude[DirectMissingMethodProblem]("sbt.librarymanagement.ArtifactTypeFilterExtra.types"),
-
       // contraband issue
-      exclude[DirectMissingMethodProblem]("sbt.internal.librarymanagement.ConfigurationReportLite.copy*"),
+      exclude[DirectMissingMethodProblem](
+        "sbt.internal.librarymanagement.ConfigurationReportLite.copy*"
+      ),
       exclude[DirectMissingMethodProblem]("sbt.internal.librarymanagement.UpdateReportLite.copy*"),
       exclude[DirectMissingMethodProblem]("sbt.librarymanagement.Artifact.copy*"),
       exclude[DirectMissingMethodProblem]("sbt.librarymanagement.ArtifactTypeFilter.copy*"),
@@ -189,7 +201,9 @@ lazy val lmCore = (project in file("core"))
       exclude[DirectMissingMethodProblem]("sbt.librarymanagement.FileConfiguration.copy*"),
       exclude[DirectMissingMethodProblem]("sbt.librarymanagement.FileRepository.copy*"),
       exclude[DirectMissingMethodProblem]("sbt.librarymanagement.Full.copy*"),
-      exclude[DirectMissingMethodProblem]("sbt.librarymanagement.GetClassifiersConfiguration.copy*"),
+      exclude[DirectMissingMethodProblem](
+        "sbt.librarymanagement.GetClassifiersConfiguration.copy*"
+      ),
       exclude[DirectMissingMethodProblem]("sbt.librarymanagement.GetClassifiersModule.copy*"),
       exclude[DirectMissingMethodProblem]("sbt.librarymanagement.InclExclRule.copy*"),
       exclude[DirectMissingMethodProblem]("sbt.librarymanagement.IvyFileConfiguration.copy*"),
@@ -198,7 +212,9 @@ lazy val lmCore = (project in file("core"))
       exclude[DirectMissingMethodProblem]("sbt.librarymanagement.MavenCache.copy*"),
       exclude[DirectMissingMethodProblem]("sbt.librarymanagement.MavenRepo.copy*"),
       exclude[DirectMissingMethodProblem]("sbt.librarymanagement.ModuleConfiguration.copy*"),
-      exclude[DirectMissingMethodProblem]("sbt.librarymanagement.ModuleDescriptorConfiguration.copy*"),
+      exclude[DirectMissingMethodProblem](
+        "sbt.librarymanagement.ModuleDescriptorConfiguration.copy*"
+      ),
       exclude[DirectMissingMethodProblem]("sbt.librarymanagement.ModuleID.copy*"),
       exclude[DirectMissingMethodProblem]("sbt.librarymanagement.ModuleInfo.copy*"),
       exclude[DirectMissingMethodProblem]("sbt.librarymanagement.ModuleReport.copy*"),
@@ -218,6 +234,10 @@ lazy val lmCore = (project in file("core"))
       exclude[DirectMissingMethodProblem]("sbt.librarymanagement.UpdateReport.copy*"),
       exclude[DirectMissingMethodProblem]("sbt.librarymanagement.UpdateStats.copy*"),
       exclude[DirectMissingMethodProblem]("sbt.librarymanagement.URLRepository.copy*"),
+      // private[sbt]
+      exclude[DirectMissingMethodProblem](
+        "sbt.librarymanagement.ResolverFunctions.useSecureResolvers"
+      ),
     ),
   )
   .configure(addSbtIO, addSbtUtilLogging, addSbtUtilPosition, addSbtUtilCache)
@@ -242,33 +262,68 @@ lazy val lmIvy = (project in file("ivy"))
       Vector("-Ywarn-unused-import", "-Ywarn-unused", "-Xlint"),
     mimaSettings,
     mimaBinaryIssueFilters ++= Seq(
-      exclude[DirectMissingMethodProblem]("sbt.internal.librarymanagement.ivyint.GigahorseUrlHandler#SbtUrlInfo.this"),
-      exclude[IncompatibleMethTypeProblem]("sbt.internal.librarymanagement.ivyint.GigahorseUrlHandler#SbtUrlInfo.this"),
-      exclude[DirectMissingMethodProblem]("sbt.internal.librarymanagement.ivyint.GigahorseUrlHandler.checkStatusCode"),
-
+      exclude[DirectMissingMethodProblem](
+        "sbt.internal.librarymanagement.ivyint.GigahorseUrlHandler#SbtUrlInfo.this"
+      ),
+      exclude[IncompatibleMethTypeProblem](
+        "sbt.internal.librarymanagement.ivyint.GigahorseUrlHandler#SbtUrlInfo.this"
+      ),
+      exclude[DirectMissingMethodProblem](
+        "sbt.internal.librarymanagement.ivyint.GigahorseUrlHandler.checkStatusCode"
+      ),
       // sbt.internal methods that changed type signatures and aren't used elsewhere in production code
-      exclude[DirectMissingMethodProblem]("sbt.internal.librarymanagement.IvySbt#ParallelCachedResolutionResolveEngine.mergeErrors"),
-      exclude[DirectMissingMethodProblem]("sbt.internal.librarymanagement.IvySbt.cleanCachedResolutionCache"),
+      exclude[DirectMissingMethodProblem](
+        "sbt.internal.librarymanagement.IvySbt#ParallelCachedResolutionResolveEngine.mergeErrors"
+      ),
+      exclude[DirectMissingMethodProblem](
+        "sbt.internal.librarymanagement.IvySbt.cleanCachedResolutionCache"
+      ),
       exclude[DirectMissingMethodProblem]("sbt.internal.librarymanagement.IvyRetrieve.artifacts"),
-      exclude[DirectMissingMethodProblem]("sbt.internal.librarymanagement.IvyScalaUtil.checkModule"),
-      exclude[DirectMissingMethodProblem]("sbt.internal.librarymanagement.ivyint.CachedResolutionResolveEngine.mergeErrors"),
-      exclude[DirectMissingMethodProblem]("sbt.internal.librarymanagement.ivyint.CachedResolutionResolveCache.buildArtificialModuleDescriptor"),
-      exclude[DirectMissingMethodProblem]("sbt.internal.librarymanagement.ivyint.CachedResolutionResolveCache.buildArtificialModuleDescriptors"),
-      exclude[ReversedMissingMethodProblem]("sbt.internal.librarymanagement.ivyint.CachedResolutionResolveEngine.mergeErrors"),
-
-      exclude[DirectMissingMethodProblem]("sbt.internal.librarymanagement.ivyint.GigahorseUrlHandler#SbtUrlInfo.this"),
-      exclude[IncompatibleMethTypeProblem]("sbt.internal.librarymanagement.ivyint.GigahorseUrlHandler#SbtUrlInfo.this"),
-      exclude[DirectMissingMethodProblem]("sbt.internal.librarymanagement.ivyint.GigahorseUrlHandler.checkStatusCode"),
-
+      exclude[DirectMissingMethodProblem](
+        "sbt.internal.librarymanagement.IvyScalaUtil.checkModule"
+      ),
+      exclude[DirectMissingMethodProblem](
+        "sbt.internal.librarymanagement.ivyint.CachedResolutionResolveEngine.mergeErrors"
+      ),
+      exclude[DirectMissingMethodProblem](
+        "sbt.internal.librarymanagement.ivyint.CachedResolutionResolveCache.buildArtificialModuleDescriptor"
+      ),
+      exclude[DirectMissingMethodProblem](
+        "sbt.internal.librarymanagement.ivyint.CachedResolutionResolveCache.buildArtificialModuleDescriptors"
+      ),
+      exclude[ReversedMissingMethodProblem](
+        "sbt.internal.librarymanagement.ivyint.CachedResolutionResolveEngine.mergeErrors"
+      ),
+      exclude[DirectMissingMethodProblem](
+        "sbt.internal.librarymanagement.ivyint.GigahorseUrlHandler#SbtUrlInfo.this"
+      ),
+      exclude[IncompatibleMethTypeProblem](
+        "sbt.internal.librarymanagement.ivyint.GigahorseUrlHandler#SbtUrlInfo.this"
+      ),
+      exclude[DirectMissingMethodProblem](
+        "sbt.internal.librarymanagement.ivyint.GigahorseUrlHandler.checkStatusCode"
+      ),
       // contraband issue
-      exclude[DirectMissingMethodProblem]("sbt.librarymanagement.ivy.ExternalIvyConfiguration.copy*"),
+      exclude[DirectMissingMethodProblem](
+        "sbt.librarymanagement.ivy.ExternalIvyConfiguration.copy*"
+      ),
       exclude[DirectMissingMethodProblem]("sbt.librarymanagement.ivy.InlineIvyConfiguration.copy*"),
       exclude[DirectMissingMethodProblem]("sbt.librarymanagement.ivy.IvyPaths.copy*"),
-
-      exclude[DirectMissingMethodProblem]("sbt.internal.librarymanagement.ivyint.GigahorseUrlHandler.urlFactory"),
-      exclude[DirectMissingMethodProblem]("sbt.internal.librarymanagement.ivyint.GigahorseUrlHandler.http"),
-      exclude[DirectMissingMethodProblem]("sbt.internal.librarymanagement.ivyint.GigahorseUrlHandler.open"),
-      exclude[DirectMissingMethodProblem]("sbt.internal.librarymanagement.ivyint.GigahorseUrlHandler.this"),
+      exclude[DirectMissingMethodProblem](
+        "sbt.internal.librarymanagement.ivyint.GigahorseUrlHandler.urlFactory"
+      ),
+      exclude[DirectMissingMethodProblem](
+        "sbt.internal.librarymanagement.ivyint.GigahorseUrlHandler.http"
+      ),
+      exclude[DirectMissingMethodProblem](
+        "sbt.internal.librarymanagement.ivyint.GigahorseUrlHandler.open"
+      ),
+      exclude[DirectMissingMethodProblem](
+        "sbt.internal.librarymanagement.ivyint.GigahorseUrlHandler.this"
+      ),
+      exclude[DirectMissingMethodProblem](
+        "sbt.internal.librarymanagement.CustomPomParser.versionRangeFlag"
+      ),
     ),
   )
 
@@ -278,11 +333,13 @@ lazy val lmScriptedTest = (project in file("scripted-test"))
     commonSettings,
     skip in publish := true,
     name := "scripted-test",
-    scriptedLaunchOpts := { scriptedLaunchOpts.value ++
-      Seq("-Xmx1024M", "-Dplugin.version=" + version.value)
+    scriptedLaunchOpts := {
+      scriptedLaunchOpts.value ++
+        Seq("-Xmx1024M", "-Dplugin.version=" + version.value)
     },
     scriptedBufferLog := false
-  ).enablePlugins(SbtScriptedIT)
+  )
+  .enablePlugins(SbtScriptedIT)
 
 // we are updating the nightly process, so we are commenting this out for now
 // addCommandAlias("scriptedIvy", Seq(
@@ -303,14 +360,16 @@ def customCommands: Seq[Setting[_]] = Seq(
   }
 )
 
-inThisBuild(Seq(
-  whitesourceProduct                   := "Lightbend Reactive Platform",
-  whitesourceAggregateProjectName      := "sbt-lm-master",
-  whitesourceAggregateProjectToken     := "9bde4ccbaab7401a91f8cda337af84365d379e13abaf473b85cb16e3f5c65cb6",
-  whitesourceIgnoredScopes             += "scalafmt",
-  whitesourceFailOnError               := sys.env.contains("WHITESOURCE_PASSWORD"), // fail if pwd is present
-  whitesourceForceCheckAllDependencies := true,
-))
+inThisBuild(
+  Seq(
+    whitesourceProduct := "Lightbend Reactive Platform",
+    whitesourceAggregateProjectName := "sbt-lm-master",
+    whitesourceAggregateProjectToken := "9bde4ccbaab7401a91f8cda337af84365d379e13abaf473b85cb16e3f5c65cb6",
+    whitesourceIgnoredScopes += "scalafmt",
+    whitesourceFailOnError := sys.env.contains("WHITESOURCE_PASSWORD"), // fail if pwd is present
+    whitesourceForceCheckAllDependencies := true,
+  )
+)
 
 def inCompileAndTest(ss: SettingsDefinition*): Seq[Setting[_]] =
   Seq(Compile, Test) flatMap (inConfig(_)(Def.settings(ss: _*)))

--- a/core/src/main/scala/sbt/internal/librarymanagement/LMSysProp.scala
+++ b/core/src/main/scala/sbt/internal/librarymanagement/LMSysProp.scala
@@ -10,6 +10,7 @@ package internal
 package librarymanagement
 
 import java.util.Locale
+import scala.util.control.NonFatal
 
 object LMSysProp {
   def booleanOpt(name: String): Option[Boolean] =
@@ -40,17 +41,21 @@ object LMSysProp {
 
   val useSecureResolvers: Boolean = getOrTrue("sbt.repository.secure")
 
-  def modifyVersionRange: Boolean = getOrTrue("sbt.modversionrange")
+  lazy val modifyVersionRange: Boolean = getOrTrue("sbt.modversionrange")
 
   lazy val isJavaVersion9Plus: Boolean = javaVersion > 8
   lazy val javaVersion: Int = {
-    // See Oracle section 1.5.3 at:
-    // https://docs.oracle.com/javase/8/docs/technotes/guides/versioning/spec/versioning2.html
-    val version = sys.props("java.specification.version").split("\\.").toList.map(_.toInt)
-    version match {
-      case 1 :: minor :: _ => minor
-      case major :: _      => major
-      case _               => 0
+    try {
+      // See Oracle section 1.5.3 at:
+      // https://docs.oracle.com/javase/8/docs/technotes/guides/versioning/spec/versioning2.html
+      val version = sys.props("java.specification.version").split("\\.").toList.map(_.toInt)
+      version match {
+        case 1 :: minor :: _ => minor
+        case major :: _      => major
+        case _               => 0
+      }
+    } catch {
+      case NonFatal(_) => 0
     }
   }
 

--- a/core/src/main/scala/sbt/internal/librarymanagement/LMSysProp.scala
+++ b/core/src/main/scala/sbt/internal/librarymanagement/LMSysProp.scala
@@ -1,0 +1,58 @@
+/*
+ * sbt
+ * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt
+package internal
+package librarymanagement
+
+import java.util.Locale
+
+object LMSysProp {
+  def booleanOpt(name: String): Option[Boolean] =
+    sys.props.get(name).flatMap { x =>
+      x.toLowerCase(Locale.ENGLISH) match {
+        case "1" | "always" | "true" => Some(true)
+        case "0" | "never" | "false" => Some(false)
+        case "auto"                  => None
+        case _                       => None
+      }
+    }
+
+  def getOrFalse(name: String): Boolean = booleanOpt(name).getOrElse(false)
+  def getOrTrue(name: String): Boolean = booleanOpt(name).getOrElse(true)
+
+  // System property style:
+  //   1. use sbt. prefix
+  //   2. prefer short nouns
+  //   3. use dot for namespacing, and avoid making dot-separated English phrase
+  //   4. make active/enable properties, instead of "sbt.disable."
+  //
+  // Good: sbt.offline
+  //
+  // Bad:
+  // sbt.disable.interface.classloader.cache
+  // sbt.task.timings.on.shutdown
+  // sbt.skip.version.write -> sbt.genbuildprops=false
+
+  val useSecureResolvers: Boolean = getOrTrue("sbt.repository.secure")
+
+  def modifyVersionRange: Boolean = getOrTrue("sbt.modversionrange")
+
+  lazy val isJavaVersion9Plus: Boolean = javaVersion > 8
+  lazy val javaVersion: Int = {
+    // See Oracle section 1.5.3 at:
+    // https://docs.oracle.com/javase/8/docs/technotes/guides/versioning/spec/versioning2.html
+    val version = sys.props("java.specification.version").split("\\.").toList.map(_.toInt)
+    version match {
+      case 1 :: minor :: _ => minor
+      case major :: _      => major
+      case _               => 0
+    }
+  }
+
+  lazy val useGigahorse: Boolean = getOrTrue("sbt.gigahorse")
+}

--- a/core/src/main/scala/sbt/internal/librarymanagement/LMSysProp.scala
+++ b/core/src/main/scala/sbt/internal/librarymanagement/LMSysProp.scala
@@ -54,5 +54,5 @@ object LMSysProp {
     }
   }
 
-  lazy val useGigahorse: Boolean = getOrTrue("sbt.gigahorse")
+  lazy val useGigahorse: Boolean = getOrFalse("sbt.gigahorse")
 }

--- a/core/src/main/scala/sbt/internal/librarymanagement/SemanticSelectorExtra.scala
+++ b/core/src/main/scala/sbt/internal/librarymanagement/SemanticSelectorExtra.scala
@@ -4,6 +4,7 @@ import sbt.librarymanagement.VersionNumber
 import sbt.internal.librarymanagement.SemSelOperator.{ Lt, Lte, Gt, Gte, Eq }
 
 import scala.annotation.tailrec
+import java.util.Locale
 
 private[librarymanagement] abstract class SemSelAndChunkFunctions {
   protected def parse(andClauseToken: String): SemSelAndChunk = {
@@ -123,10 +124,11 @@ private[librarymanagement] abstract class SemComparatorExtra {
         // Identifiers consisting of only digits are compared numerically.
         // Numeric identifiers always have lower precedence than non-numeric identifiers.
         // Identifiers with letters are compared case insensitive lexical order.
-        case (true, true)   => implicitly[Ordering[Long]].compare(ts1head.toLong, ts2head.toLong)
-        case (false, true)  => 1
-        case (true, false)  => -1
-        case (false, false) => ts1head.toLowerCase.compareTo(ts2head.toLowerCase)
+        case (true, true)  => implicitly[Ordering[Long]].compare(ts1head.toLong, ts2head.toLong)
+        case (false, true) => 1
+        case (true, false) => -1
+        case (false, false) =>
+          ts1head.toLowerCase(Locale.ENGLISH).compareTo(ts2head.toLowerCase(Locale.ENGLISH))
       }
       if (cmp == 0) compareTags(ts1.tail, ts2.tail)
       else cmp

--- a/core/src/main/scala/sbt/librarymanagement/ResolverExtra.scala
+++ b/core/src/main/scala/sbt/librarymanagement/ResolverExtra.scala
@@ -95,8 +95,7 @@ private[sbt] class FakeRepository(resolver: AnyRef, name: String) extends xsbti.
 }
 
 private[librarymanagement] abstract class ResolverFunctions {
-  private[sbt] def useSecureResolvers =
-    sys.props.get("sbt.repository.secure") map { _.toLowerCase == "true" } getOrElse true
+  import sbt.internal.librarymanagement.LMSysProp.useSecureResolvers
 
   val TypesafeRepositoryRoot = typesafeRepositoryRoot(useSecureResolvers)
   val SbtRepositoryRoot = sbtRepositoryRoot(useSecureResolvers)

--- a/ivy/src/main/scala/sbt/internal/librarymanagement/CustomPomParser.scala
+++ b/ivy/src/main/scala/sbt/internal/librarymanagement/CustomPomParser.scala
@@ -242,9 +242,6 @@ object CustomPomParser {
         transform(dd, _ => newId)
       case None => dd
     }
-  private[sbt] lazy val versionRangeFlag = sys.props.get("sbt.modversionrange") map {
-    _.toLowerCase == "true"
-  } getOrElse true
 
   import collection.JavaConverters._
   def addExtra(
@@ -281,7 +278,7 @@ object CustomPomParser {
       addExtra(dd, dependencyExtra)
     }
     val withVersionRangeMod: Seq[DependencyDescriptor] =
-      if (versionRangeFlag) withExtra map { stripVersionRange } else withExtra
+      if (LMSysProp.modifyVersionRange) withExtra map { stripVersionRange } else withExtra
     val unique = IvySbt.mergeDuplicateDefinitions(withVersionRangeMod)
     unique foreach dmd.addDependency
 

--- a/ivy/src/main/scala/sbt/internal/librarymanagement/ivyint/ErrorMessageAuthenticator.scala
+++ b/ivy/src/main/scala/sbt/internal/librarymanagement/ivyint/ErrorMessageAuthenticator.scala
@@ -15,7 +15,8 @@ object ErrorMessageAuthenticator {
   private var securityWarningLogged = false
 
   private def originalAuthenticator: Option[Authenticator] = {
-    if (isJavaVersion9Plus) getDefaultAuthenticator else getTheAuthenticator
+    if (LMSysProp.isJavaVersion9Plus) getDefaultAuthenticator
+    else getTheAuthenticator
   }
 
   private[this] def getTheAuthenticator: Option[Authenticator] = {
@@ -100,15 +101,6 @@ object ErrorMessageAuthenticator {
       }
     doInstallIfIvy(originalAuthenticator)
   }
-
-  private[this] def isJavaVersion9Plus = javaVersion > 8
-  private[this] def javaVersion = {
-    // See Oracle section 1.5.3 at:
-    // https://docs.oracle.com/javase/8/docs/technotes/guides/versioning/spec/versioning2.html
-    val version = sys.props("java.specification.version").split("\\.").map(_.toInt)
-    if (version(0) == 1) version(1) else version(0)
-  }
-
 }
 
 /**

--- a/ivy/src/main/scala/sbt/librarymanagement/ivy/UpdateOptions.scala
+++ b/ivy/src/main/scala/sbt/librarymanagement/ivy/UpdateOptions.scala
@@ -4,6 +4,7 @@ package ivy
 import org.apache.ivy.plugins.resolver.DependencyResolver
 import org.apache.ivy.core.settings.IvySettings
 import sbt.util.Logger
+import sbt.internal.librarymanagement.LMSysProp
 
 /**
  * Represents configurable options for update task.
@@ -109,7 +110,7 @@ object UpdateOptions {
       interProjectFirst = true,
       latestSnapshots = true,
       cachedResolution = false,
-      gigahorse = sys.props.get("sbt.gigahorse") map { _.toLowerCase == "true" } getOrElse true,
+      gigahorse = LMSysProp.useGigahorse,
       resolverConverter = PartialFunction.empty,
       moduleResolvers = Map.empty
     )


### PR DESCRIPTION
Fixes sbt/sbt#3570

The primary motivation for bringing in Gigahorse was to speed up the dependency resolution, especially in a high-latency environment like Australia, by enabling keep-alive. One of unintended consequences was that it ended up exposing either a bug in okhttp or Nexus / Artifactory's handling of keep-alive, since corporate users behind these proxy repositories started to experience problem publishing. Multiple people have also reported that putting network proxies like HAProxy works around this issue, which seems consistent with the theory.

Now that dependency resolution has switched to using Coursier by default, I am just going to flip the default here so publishing would use Ivy's default URL handler based on `java.net.HttpURLConnection` - https://github.com/sbt/ivy/blob/5681e1a77a149b93a4cfbe4a86d0263d7bd223eb/src/java/org/apache/ivy/util/url/BasicURLHandler.java