### PR TITLE
UpdateOptions: make latestSnapshots = false the default

### DIFF
--- a/ivy/src/main/scala/sbt/internal/librarymanagement/ivyint/SbtChainResolver.scala
+++ b/ivy/src/main/scala/sbt/internal/librarymanagement/ivyint/SbtChainResolver.scala
@@ -225,9 +225,6 @@ private[sbt] case class SbtChainResolver(
 
         if (resolvedModule.getId.getRevision.contains("SNAPSHOT")) {
 
-          Message.warn(
-            "Resolving a snapshot version. It's going to be slow unless you use `updateOptions := updateOptions.value.withLatestSnapshots(false)` options."
-          )
           val resolvers = sortedRevisions.map(_._2.getName)
           sortedRevisions.foreach(h => {
             val (module, resolver) = h

--- a/ivy/src/main/scala/sbt/librarymanagement/ivy/UpdateOptions.scala
+++ b/ivy/src/main/scala/sbt/librarymanagement/ivy/UpdateOptions.scala
@@ -108,7 +108,7 @@ object UpdateOptions {
     new UpdateOptions(
       circularDependencyLevel = CircularDependencyLevel.Warn,
       interProjectFirst = true,
-      latestSnapshots = true,
+      latestSnapshots = false,
       cachedResolution = false,
       gigahorse = LMSysProp.useGigahorse,
       resolverConverter = PartialFunction.empty,


### PR DESCRIPTION
I'm not aware of a single person who enjoys this feature. In fact, it is
so cursed that sbt warns you every time you accidentally use it (and
turning it off properly is non-trivial: setting it in the current
project is not enough, you'll need to set it in the meta-project,
meta-meta-project, etc).

Let's do the right thing for our users by giving them sensible defaults
instead.