### PR TITLE
Automatic eviction warning

### DIFF
--- a/core/src/main/java/sbt/internal/librarymanagement/mavenint/SbtPomExtraProperties.java
+++ b/core/src/main/java/sbt/internal/librarymanagement/mavenint/SbtPomExtraProperties.java
@@ -13,6 +13,7 @@ public class SbtPomExtraProperties {
     public static final String POM_SCALA_VERSION = "scalaVersion";
     public static final String POM_SBT_VERSION = "sbtVersion";
     public static final String POM_API_KEY = "info.apiURL";
+    public static final String VERSION_SCHEME_KEY = "info.versionScheme";
 
     public static final String LICENSE_COUNT_KEY = "license.count";
 

--- a/core/src/main/scala/sbt/internal/librarymanagement/VersionSchemes.scala
+++ b/core/src/main/scala/sbt/internal/librarymanagement/VersionSchemes.scala
@@ -1,0 +1,43 @@
+/*
+ * sbt
+ * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt
+package internal
+package librarymanagement
+
+import sbt.internal.librarymanagement.mavenint.SbtPomExtraProperties
+import sbt.librarymanagement.ModuleID
+
+// See APIMappings.scala
+private[sbt] object VersionSchemes {
+  final val EarlySemVer = "early-semver"
+  final val SemVerSpec = "semver-spec"
+  final val PackVer = "pvp"
+
+  def validateScheme(value: String): Unit =
+    value match {
+      case EarlySemVer | SemVerSpec | PackVer => ()
+      case "semver" =>
+        sys.error(
+          s"""'semver' is ambiguous.
+             |Based on the Semantic Versioning 2.0.0, 0.y.z updates are all initial development and thus
+             |0.6.0 and 0.6.1 would NOT maintain any compatibility, but in Scala ecosystem it is
+             |common to start adopting binary compatibility even in 0.y.z releases.
+             |
+             |Specify 'early-semver' for the early variant.
+             |Specify 'semver-spec' for the spec-correct SemVer.""".stripMargin
+        )
+      case x => sys.error(s"unknown version scheme: $x")
+    }
+
+  /** info.versionScheme property will be included into POM after sbt 1.4.0.
+   */
+  def extractFromId(mid: ModuleID): Option[String] = extractFromExtraAttributes(mid.extraAttributes)
+
+  def extractFromExtraAttributes(extraAttributes: Map[String, String]): Option[String] =
+    extraAttributes.get(SbtPomExtraProperties.VERSION_SCHEME_KEY)
+}

--- a/core/src/test/scala/sbt/librarymanagement/VersionNumberSpec.scala
+++ b/core/src/test/scala/sbt/librarymanagement/VersionNumberSpec.scala
@@ -4,7 +4,7 @@ import org.scalatest.{ FreeSpec, Inside, Matchers }
 
 // This is a specification to check VersionNumber and VersionNumberCompatibility.
 class VersionNumberSpec extends FreeSpec with Matchers with Inside {
-  import VersionNumber.{ SemVer, SecondSegment }
+  import VersionNumber.{ EarlySemVer, SemVer, PackVer }
 
   version("1") { v =>
     assertParsesTo(v, Seq(1), Seq(), Seq())
@@ -28,10 +28,15 @@ class VersionNumberSpec extends FreeSpec with Matchers with Inside {
     assertIsNotCompatibleWith(v, "2.0.0", SemVer)
     assertIsNotCompatibleWith(v, "1.0.0-M1", SemVer)
 
-    assertIsCompatibleWith(v, "1.0.1", SecondSegment)
-    assertIsNotCompatibleWith(v, "1.1.1", SecondSegment)
-    assertIsNotCompatibleWith(v, "2.0.0", SecondSegment)
-    assertIsNotCompatibleWith(v, "1.0.0-M1", SecondSegment)
+    assertIsCompatibleWith(v, "1.0.1", EarlySemVer)
+    assertIsCompatibleWith(v, "1.1.1", EarlySemVer)
+    assertIsNotCompatibleWith(v, "2.0.0", EarlySemVer)
+    assertIsNotCompatibleWith(v, "1.0.0-M1", EarlySemVer)
+
+    assertIsCompatibleWith(v, "1.0.1", PackVer)
+    assertIsNotCompatibleWith(v, "1.1.1", PackVer)
+    assertIsNotCompatibleWith(v, "2.0.0", PackVer)
+    assertIsNotCompatibleWith(v, "1.0.0-M1", PackVer)
   }
 
   version("1.0.0.0") { v =>
@@ -49,9 +54,13 @@ class VersionNumberSpec extends FreeSpec with Matchers with Inside {
     assertIsNotCompatibleWith(v, "0.12.1", SemVer)
     assertIsNotCompatibleWith(v, "0.12.1-M1", SemVer)
 
-    assertIsNotCompatibleWith(v, "0.12.0-RC1", SecondSegment)
-    assertIsCompatibleWith(v, "0.12.1", SecondSegment)
-    assertIsCompatibleWith(v, "0.12.1-M1", SecondSegment)
+    assertIsNotCompatibleWith(v, "0.12.0-RC1", EarlySemVer)
+    assertIsCompatibleWith(v, "0.12.1", EarlySemVer)
+    assertIsCompatibleWith(v, "0.12.1-M1", EarlySemVer)
+
+    assertIsNotCompatibleWith(v, "0.12.0-RC1", PackVer)
+    assertIsCompatibleWith(v, "0.12.1", PackVer)
+    assertIsCompatibleWith(v, "0.12.1-M1", PackVer)
   }
 
   version("0.1.0-SNAPSHOT") { v =>
@@ -62,9 +71,13 @@ class VersionNumberSpec extends FreeSpec with Matchers with Inside {
     assertIsNotCompatibleWith(v, "0.1.0", SemVer)
     assertIsCompatibleWith(v, "0.1.0-SNAPSHOT+001", SemVer)
 
-    assertIsCompatibleWith(v, "0.1.0-SNAPSHOT", SecondSegment)
-    assertIsNotCompatibleWith(v, "0.1.0", SecondSegment)
-    assertIsCompatibleWith(v, "0.1.0-SNAPSHOT+001", SecondSegment)
+    assertIsCompatibleWith(v, "0.1.0-SNAPSHOT", EarlySemVer)
+    assertIsNotCompatibleWith(v, "0.1.0", EarlySemVer)
+    assertIsCompatibleWith(v, "0.1.0-SNAPSHOT+001", EarlySemVer)
+
+    assertIsCompatibleWith(v, "0.1.0-SNAPSHOT", PackVer)
+    assertIsNotCompatibleWith(v, "0.1.0", PackVer)
+    assertIsCompatibleWith(v, "0.1.0-SNAPSHOT+001", PackVer)
   }
 
   version("0.1.0-M1") { v =>
@@ -86,7 +99,7 @@ class VersionNumberSpec extends FreeSpec with Matchers with Inside {
     assertParsesTo(v, Seq(2, 10, 4), Seq("20140115", "000117", "b3a", "sources"), Seq())
     assertCascadesTo(v, Seq("2.10.4-20140115-000117-b3a-sources", "2.10.4", "2.10"))
     assertIsCompatibleWith(v, "2.0.0", SemVer)
-    assertIsNotCompatibleWith(v, "2.0.0", SecondSegment)
+    assertIsNotCompatibleWith(v, "2.0.0", PackVer)
   }
 
   version("20140115000117-b3a-sources") { v =>
@@ -187,9 +200,10 @@ class VersionNumberSpec extends FreeSpec with Matchers with Inside {
   ) = {
     val prefix = if (expectOutcome) "should" else "should NOT"
     val compatibilityStrategy = vnc match {
-      case SemVer        => "SemVer"
-      case SecondSegment => "SecondSegment"
-      case _             => val s = vnc.name; if (s contains " ") s""""$s"""" else s
+      case SemVer      => "SemVer"
+      case PackVer     => "PackVer"
+      case EarlySemVer => "EarlySemVer"
+      case _           => val s = vnc.name; if (s contains " ") s""""$s"""" else s
     }
     s"$prefix be $compatibilityStrategy compatible with $v2" in {
       vnc.isCompatible(VersionNumber(v1.value), VersionNumber(v2)) shouldBe expectOutcome


### PR DESCRIPTION
Ref https://github.com/sbt/sbt/issues/5710

This extracts info.versionScheme from POM and uses that to guide the
eviction report instead of taking a stab in the dark that all Scala
libraries are using pvp.