### PR TITLE
Ivy 2.3.0-sbt-fbc4f586aeeb1591710b14eb4f41b94880dcd745

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -42,7 +42,7 @@ object Dependencies {
   def addSbtUtilCache(p: Project): Project = addSbtModule(p, sbtUtilPath, "utilCache", utilCache)
 
   val launcherInterface = "org.scala-sbt" % "launcher-interface" % "1.0.0"
-  val ivy = "org.scala-sbt.ivy" % "ivy" % "2.3.0-sbt-839fad1cdc07cf6fc81364d74c323867230432ad"
+  val ivy = "org.scala-sbt.ivy" % "ivy" % "2.3.0-sbt-fbc4f586aeeb1591710b14eb4f41b94880dcd745"
 
   val sbtV = "1.0"
   val scalaV = "2.12"


### PR DESCRIPTION
Update SBT-Ivy to the latest version in order to take advantage of sbt/ivy#40

This should close sbt/sbt#5483