### PR TITLE
Add Ordering For VersionNumber

### DIFF
--- a/core/src/main/scala/sbt/librarymanagement/VersionNumber.scala
+++ b/core/src/main/scala/sbt/librarymanagement/VersionNumber.scala
@@ -260,9 +260,9 @@ object VersionNumber {
    *
    * This ordering compares a version number first by comparing the
    * numbers. Numbers with less components are ordered < longer ones,
-   * e.g. `"1.0" < "1.0.0" == true`. If the [[VersionNumber#numbers]] is
-   * equal then [[VersionNumber#tags]] is compared. If [[VersionNumber#tags]]
-   * is equal then [[VersionNumber#extra]] is compared.
+   * e.g. `"1.0" < "1.0.0" == true`. If the [[VersionNumber#numbers]] is equal
+   * then [[VersionNumber#tags]] is compared. If [[VersionNumber#tags]] is
+   * equal then [[VersionNumber#extras]] is compared.
    *
    * This ordering will be consistent with [[VersionNumber#equals]].
    */

--- a/core/src/test/scala/sbt/librarymanagement/VersionNumberSpec.scala
+++ b/core/src/test/scala/sbt/librarymanagement/VersionNumberSpec.scala
@@ -124,6 +124,25 @@ class VersionNumberSpec extends FreeSpec with Matchers with Inside {
     assertParsesToError(v)
   }
 
+  "VersionNumber.ordering" - {
+    "should compare differing values as expected" in {
+      assert(
+        VersionNumber.ordering.compare(
+          VersionNumber("1.0.0"),
+          VersionNumber("2.0.0")
+        ) < 0
+      )
+    }
+    "should be consistent with .equals" in {
+      assert(
+        VersionNumber.ordering.compare(
+          VersionNumber("1.0.0"),
+          VersionNumber("1.0.0")
+        ) == 0
+      )
+    }
+  }
+
   ////
 
   private[this] final class VersionString(val value: String)


### PR DESCRIPTION
This commit adds an `Ordering` to the companion object for `VersionNumber`. This is nice in many context, e.g. working with MiMa, writing plugins, etc.