### PR TITLE
Add Scala 3 artifacts and binary versioning

### DIFF
--- a/core/src/test/scala/sbt/librarymanagement/CrossVersionTest.scala
+++ b/core/src/test/scala/sbt/librarymanagement/CrossVersionTest.scala
@@ -207,8 +207,35 @@ class CrossVersionTest extends UnitSpec {
   it should "for 2.20170314093845.0-87654321 return 2.20170314093845" in {
     binaryScalaVersion("2.20170314093845.0-87654321") shouldBe "2.20170314093845"
   }
-  it should "for Dotty 0.1.1 return 0.1" in {
-    binaryScalaVersion("0.1.1") shouldBe "0.1"
+  it should "for 3.0.0-M2 return 3.0.0-M2" in {
+    binaryScalaVersion("3.0.0-M2") shouldBe "3.0.0-M2"
+  }
+  it should "for 3.0.0-M3-bin-SNAPSHOT return 3.0.0-M3" in {
+    binaryScalaVersion("3.0.0-M3-bin-SNAPSHOT") shouldBe "3.0.0-M3"
+  }
+  it should "for 3.0.0-M3-bin-20201215-cbe50b3-NIGHTLY return 3.0.0-M3" in {
+    binaryScalaVersion("3.0.0-M3-bin-20201215-cbe50b3-NIGHTLY") shouldBe "3.0.0-M3"
+  }
+  it should "for 3.0.0-RC1 return 3.0.0-RC1" in {
+    binaryScalaVersion("3.0.0-RC1") shouldBe "3.0.0-RC1"
+  }
+
+  // Not set in stone but 3 is the favorite candidate so far
+  // (see https://github.com/lampepfl/dotty/issues/10244)
+  it should "for 3.0.0 return 3" in {
+    binaryScalaVersion("3.0.0") shouldBe "3"
+  }
+  it should "for 3.1.0-M1 return 3" in {
+    binaryScalaVersion("3.1.0-M1") shouldBe "3"
+  }
+  it should "for 3.1.0-RC1-bin-SNAPSHOT return 3" in {
+    binaryScalaVersion("3.1.0-RC1-bin-SNAPSHOT") shouldBe "3"
+  }
+  it should "for 3.1.0-RC1 return 3" in {
+    binaryScalaVersion("3.1.0-RC1") shouldBe "3"
+  }
+  it should "for 3.1.0 return 3" in {
+    binaryScalaVersion("3.1.0") shouldBe "3"
   }
 
   private def patchVersion(fullVersion: String) =


### PR DESCRIPTION
Part of https://github.com/sbt/sbt/issues/6080

### Implement the binary version logic for Scala 3:
| scalaVersion | scalaBinaryVersion |
|-|-|
| 3.0.0-M2 | 3.0.0-M2 |
| 3.0.0-M3-bin-SNAPSHOT | 3.0.0-M3 |
| 3.0.0-M3-bin-20201215-cbe50b3-NIGHTLY | 3.0.0-M3 |
| 3.0.0-RC1 | 3.0.0-RC1 |
| 3.0.0 | 3 |

`3` will most probably become the official binary version of the `3.x` series where `x < T` (https://github.com/lampepfl/dotty/issues/10244#issuecomment-746278546).
It is already implemented here so that sbt `1.5.0-M1` that will precede Scala `3.0.0` release does not conflict with it in terms of binary version.

### Add the Scala 3 artifacts
- `scala3-compiler`
- `scala3-library`