### PR TITLE
Adapt ScalaOverride to Scala 3

### DIFF
--- a/core/src/main/scala/sbt/librarymanagement/ScalaArtifacts.scala
+++ b/core/src/main/scala/sbt/librarymanagement/ScalaArtifacts.scala
@@ -1,16 +1,30 @@
 package sbt.librarymanagement
 
 object ScalaArtifacts {
-  val Organization = "org.scala-lang"
-  val LibraryID = "scala-library"
-  val CompilerID = "scala-compiler"
-  val ReflectID = "scala-reflect"
-  val ActorsID = "scala-actors"
-  val ScalapID = "scalap"
-  val Artifacts = Vector(LibraryID, CompilerID, ReflectID, ActorsID, ScalapID)
+  final val Organization = "org.scala-lang"
+  final val LibraryID = "scala-library"
+  final val CompilerID = "scala-compiler"
+  final val ReflectID = "scala-reflect"
+  final val ActorsID = "scala-actors"
+  final val ScalapID = "scalap"
+  final val Artifacts = Vector(LibraryID, CompilerID, ReflectID, ActorsID, ScalapID)
 
-  val Scala3LibraryID = "scala3-library"
-  val Scala3CompilerID = "scala3-compiler"
+  final val Scala3LibraryID = "scala3-library"
+  final val Scala3CompilerID = "scala3-compiler"
+  final val Scala3InterfacesID = "scala3-interfaces"
+  final val TastyCoreID = "tasty-core"
+
+  private[sbt] final val Scala3LibraryPrefix = Scala3LibraryID + "_"
+  private[sbt] final val Scala3CompilerPrefix = Scala3CompilerID + "_"
+  private[sbt] final val TastyCorePrefix = TastyCoreID + "_"
+
+  def isScala2Artifact(name: String): Boolean = {
+    name == LibraryID || name == CompilerID || name == ReflectID || name == ActorsID || name == ScalapID
+  }
+  def isScala3Artifact(name: String): Boolean = {
+    name.startsWith(Scala3LibraryPrefix) || name.startsWith(Scala3CompilerPrefix) ||
+    name.startsWith(TastyCorePrefix) || name == Scala3InterfacesID
+  }
 
   def isScala3(scalaVersion: String): Boolean = scalaVersion.startsWith("3.")
 

--- a/ivy/src/test/scala/sbt/internal/librarymanagement/ScalaOverrideTest.scala
+++ b/ivy/src/test/scala/sbt/internal/librarymanagement/ScalaOverrideTest.scala
@@ -11,10 +11,13 @@ import verify.BasicTestSuite
 object ScalaOverrideTest extends BasicTestSuite {
   val OtherOrgID = "other.org"
 
-  def check(org0: String, version0: String)(org1: String, name1: String, version1: String) = {
-    val scalaConfigs = Configurations.default.toVector filter { Configurations.underScalaVersion } map {
-      _.name
-    }
+  private val scalaConfigs =
+    Configurations.default.filter(Configurations.underScalaVersion).map(_.name)
+
+  def checkOrgAndVersion(
+      org0: String,
+      version0: String
+  )(org1: String, name1: String, version1: String): Unit = {
     val osm = new OverrideScalaMediator(org0, version0, scalaConfigs)
 
     val mrid = ModuleRevisionId.newInstance(org1, name1, version1)
@@ -25,8 +28,36 @@ object ScalaOverrideTest extends BasicTestSuite {
     assert(res.getDependencyRevisionId == ModuleRevisionId.newInstance(org0, name1, version0))
   }
 
-  test("""OverrideScalaMediator should override compiler version""") {
-    check(Organization, "2.11.8")(
+  def checkOnlyOrg(
+      org0: String,
+      version0: String
+  )(org1: String, name1: String, version1: String): Unit = {
+    val osm = new OverrideScalaMediator(org0, version0, scalaConfigs)
+
+    val mrid = ModuleRevisionId.newInstance(org1, name1, version1)
+    val dd = new DefaultDependencyDescriptor(mrid, false)
+    dd.addDependencyConfiguration("compile", "compile")
+
+    val res = osm.mediate(dd)
+    assert(res.getDependencyRevisionId == ModuleRevisionId.newInstance(org0, name1, version1))
+  }
+
+  def checkNoOverride(
+      org0: String,
+      version0: String
+  )(org1: String, name1: String, version1: String): Unit = {
+    val osm = new OverrideScalaMediator(org0, version0, scalaConfigs)
+
+    val mrid = ModuleRevisionId.newInstance(org1, name1, version1)
+    val dd = new DefaultDependencyDescriptor(mrid, false)
+    dd.addDependencyConfiguration("compile", "compile")
+
+    val res = osm.mediate(dd)
+    assert(res.getDependencyRevisionId == mrid)
+  }
+
+  test("OverrideScalaMediator should override compiler version") {
+    checkOrgAndVersion(Organization, "2.11.8")(
       Organization,
       CompilerID,
       "2.11.9"
@@ -34,7 +65,7 @@ object ScalaOverrideTest extends BasicTestSuite {
   }
 
   test("it should override library version") {
-    check(Organization, "2.11.8")(
+    checkOrgAndVersion(Organization, "2.11.8")(
       Organization,
       LibraryID,
       "2.11.8"
@@ -42,7 +73,7 @@ object ScalaOverrideTest extends BasicTestSuite {
   }
 
   test("it should override reflect version") {
-    check(Organization, "2.11.8")(
+    checkOrgAndVersion(Organization, "2.11.8")(
       Organization,
       ReflectID,
       "2.11.7"
@@ -50,7 +81,7 @@ object ScalaOverrideTest extends BasicTestSuite {
   }
 
   test("it should override actors version") {
-    check(Organization, "2.11.8")(
+    checkOrgAndVersion(Organization, "2.11.8")(
       Organization,
       ActorsID,
       "2.11.6"
@@ -58,7 +89,7 @@ object ScalaOverrideTest extends BasicTestSuite {
   }
 
   test("it should override scalap version") {
-    check(Organization, "2.11.8")(
+    checkOrgAndVersion(Organization, "2.11.8")(
       Organization,
       ScalapID,
       "2.11.5"
@@ -66,7 +97,7 @@ object ScalaOverrideTest extends BasicTestSuite {
   }
 
   test("it should override default compiler organization") {
-    check(OtherOrgID, "2.11.8")(
+    checkOrgAndVersion(OtherOrgID, "2.11.8")(
       Organization,
       CompilerID,
       "2.11.9"
@@ -74,7 +105,7 @@ object ScalaOverrideTest extends BasicTestSuite {
   }
 
   test("it should override default library organization") {
-    check(OtherOrgID, "2.11.8")(
+    checkOrgAndVersion(OtherOrgID, "2.11.8")(
       Organization,
       LibraryID,
       "2.11.8"
@@ -82,7 +113,7 @@ object ScalaOverrideTest extends BasicTestSuite {
   }
 
   test("it should override default reflect organization") {
-    check(OtherOrgID, "2.11.8")(
+    checkOrgAndVersion(OtherOrgID, "2.11.8")(
       Organization,
       ReflectID,
       "2.11.7"
@@ -90,7 +121,7 @@ object ScalaOverrideTest extends BasicTestSuite {
   }
 
   test("it should override default actors organization") {
-    check(OtherOrgID, "2.11.8")(
+    checkOrgAndVersion(OtherOrgID, "2.11.8")(
       Organization,
       ActorsID,
       "2.11.6"
@@ -98,7 +129,7 @@ object ScalaOverrideTest extends BasicTestSuite {
   }
 
   test("it should override default scalap organization") {
-    check(OtherOrgID, "2.11.8")(
+    checkOrgAndVersion(OtherOrgID, "2.11.8")(
       Organization,
       ScalapID,
       "2.11.5"
@@ -106,7 +137,7 @@ object ScalaOverrideTest extends BasicTestSuite {
   }
 
   test("it should override custom compiler organization") {
-    check(Organization, "2.11.8")(
+    checkOrgAndVersion(Organization, "2.11.8")(
       OtherOrgID,
       CompilerID,
       "2.11.9"
@@ -114,7 +145,7 @@ object ScalaOverrideTest extends BasicTestSuite {
   }
 
   test("it should override custom library organization") {
-    check(Organization, "2.11.8")(
+    checkOrgAndVersion(Organization, "2.11.8")(
       OtherOrgID,
       LibraryID,
       "2.11.8"
@@ -122,7 +153,7 @@ object ScalaOverrideTest extends BasicTestSuite {
   }
 
   test("it should override custom reflect organization") {
-    check(Organization, "2.11.8")(
+    checkOrgAndVersion(Organization, "2.11.8")(
       OtherOrgID,
       ReflectID,
       "2.11.7"
@@ -130,7 +161,7 @@ object ScalaOverrideTest extends BasicTestSuite {
   }
 
   test("it should override custom actors organization") {
-    check(Organization, "2.11.8")(
+    checkOrgAndVersion(Organization, "2.11.8")(
       OtherOrgID,
       ActorsID,
       "2.11.6"
@@ -138,10 +169,106 @@ object ScalaOverrideTest extends BasicTestSuite {
   }
 
   test("it should override custom scalap organization") {
-    check(Organization, "2.11.8")(
+    checkOrgAndVersion(Organization, "2.11.8")(
       OtherOrgID,
       ScalapID,
       "2.11.5"
+    )
+  }
+
+  test("it should override Scala 3 compiler version") {
+    checkOrgAndVersion(Organization, "3.1.0")(
+      Organization,
+      Scala3CompilerPrefix + "3",
+      "3.0.0"
+    )
+  }
+
+  test("it should override Scala 3 library version") {
+    checkOrgAndVersion(Organization, "3.1.0")(
+      Organization,
+      Scala3LibraryPrefix + "3",
+      "3.0.0"
+    )
+  }
+
+  test("it should override Scala 3 interfaces version") {
+    checkOrgAndVersion(Organization, "3.1.0")(
+      Organization,
+      Scala3InterfacesID,
+      "3.0.0"
+    )
+  }
+
+  test("it should override TASTy core version") {
+    checkOrgAndVersion(Organization, "3.1.0")(
+      Organization,
+      TastyCorePrefix + "3",
+      "3.0.0"
+    )
+  }
+
+  test("it should not override Scala 2 library version when using Scala 3") {
+    checkNoOverride(Organization, "3.1.0")(
+      Organization,
+      LibraryID,
+      "2.13.4"
+    )
+  }
+
+  test("it should not override TASTy core version when using Scala 2") {
+    checkNoOverride(Organization, "2.13.4")(
+      Organization,
+      TastyCorePrefix + "3",
+      "3.0.0"
+    )
+  }
+
+  test("it should override default Scala 3 compiler organization") {
+    checkOrgAndVersion(OtherOrgID, "3.1.0")(
+      Organization,
+      Scala3CompilerPrefix + "3",
+      "3.0.0"
+    )
+  }
+
+  test("it should override default Scala 3 library organization") {
+    checkOrgAndVersion(OtherOrgID, "3.1.0")(
+      Organization,
+      Scala3LibraryPrefix + "3",
+      "3.0.0"
+    )
+  }
+
+  test("it should override default Scala 3 interfaces organization") {
+    checkOrgAndVersion(OtherOrgID, "3.1.0")(
+      Organization,
+      Scala3InterfacesID,
+      "3.0.0"
+    )
+  }
+
+  test("it should override default Scala 3 TASTy core organization") {
+    checkOrgAndVersion(OtherOrgID, "3.1.0")(
+      Organization,
+      TastyCorePrefix + "3",
+      "3.0.0"
+    )
+  }
+
+  test("it should override default Scala 2 library organization when in Scala 3") {
+    checkOnlyOrg(OtherOrgID, "3.1.0")(
+      Organization,
+      LibraryID,
+      "2.13.4"
+    )
+  }
+
+  test("it should override default TASTy core organization when in Scala 2") {
+    checkOnlyOrg(OtherOrgID, "2.13.4")(
+      Organization,
+      TastyCorePrefix + "3",
+      "3.0.0"
     )
   }
 }


### PR DESCRIPTION
This PR makes possible to use `overrideScalaVersion` with Ivy and Scala 3.

When using Scala 3, it overrides the version of `scala3-library`, `scala3-compiler`, `scala3-intefaces` and `dotty-core` but not the version of `scala-library` or other Scala 2 artifacts.

The other way around, when using Scala 2, it overrides the version of the Scala 2 artifacts but not the version of the Scala 3 artifacts (we can use the Scala 3 artifacts in Scala `2.13.4` with `-Ytasty-reader`).

Also it overrides the organization of all Scala 2 and Scala 3 artifacts.

It fixes the pending `scala3-scala-organization` scripted test in https://github.com/sbt/sbt/pull/6206