### PR TITLE
Fixes match error when using withDottyCompat

### DIFF
--- a/ivy/src/test/scala/sbt/internal/librarymanagement/EvictionWarningSpec.scala
+++ b/ivy/src/test/scala/sbt/internal/librarymanagement/EvictionWarningSpec.scala
@@ -283,6 +283,24 @@ object EvictionWarningSpec extends BaseIvySpecification {
     )
   }
 
+  test("Comparing 2.13 libraries with pvp under Scala 3.0.0-M3 should work") {
+    val m1 = "org.scodec" % "scodec-bits_2.13" % "1.1.21"
+    val m2 = "org.scodec" % "scodec-bits_2.13" % "1.1.22"
+    assert(
+      EvictionWarningOptions
+        .evalPvp((m1, Option(m2), Option(dummyScalaModuleInfo("3.0.0-M3"))))
+    )
+  }
+
+  test("Comparing 2.13 libraries with guessSecondSegment under Scala 3.0.0-M3 should work") {
+    val m1 = "org.scodec" % "scodec-bits_2.13" % "1.1.21"
+    val m2 = "org.scodec" % "scodec-bits_2.13" % "1.1.22"
+    assert(
+      EvictionWarningOptions
+        .guessSecondSegment((m1, Option(m2), Option(dummyScalaModuleInfo("3.0.0-M3"))))
+    )
+  }
+
   def akkaActor214 =
     ModuleID("com.typesafe.akka", "akka-actor", "2.1.4").withConfigurations(Some("compile")) cross CrossVersion.binary
   def akkaActor230 =

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.2
+sbt.version=1.4.5


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/6210

scodec-bits is published with pvp `versionScheme` (nice), this means that we should just evaluate the version portion for pvp-ness, but I was using `guessSecondSegment` that checks for Scala suffix. That's mistake 1.

`guessSecondSegment` assumes that the Scala suffix uses the given ScalaModuleInfo, but with 2.13-3 sandwich we can't assume this. In the reported case, Scala module is 3.0.0-M3 but scodec-bits uses 2.13. So that's mistake 2.

This attempts to correct both the mistakes.
1. Instead of `guessSecondSegment`, this adds a simpler `evalPvp` function.
2. `guessSecondSegment` just looks for `_2.` or `_3` and ignores the Scala module.
