### PR TITLE
Make ModuleID#cross(...) preserve existing prefix

### DIFF
--- a/core/src/main/scala/sbt/librarymanagement/CrossVersionExtra.scala
+++ b/core/src/main/scala/sbt/librarymanagement/CrossVersionExtra.scala
@@ -17,14 +17,10 @@ private[librarymanagement] abstract class CrossVersionFunctions {
   final val Constant = sbt.librarymanagement.Constant
   final val Full = sbt.librarymanagement.Full
   final val Patch = sbt.librarymanagement.Patch
-  final val For3Use2_13 = sbt.librarymanagement.For3Use2_13
-  final val For2_13Use3 = sbt.librarymanagement.For2_13Use3
   type Binary = sbt.librarymanagement.Binary
   type Constant = sbt.librarymanagement.Constant
   type Full = sbt.librarymanagement.Full
   type Patch = sbt.librarymanagement.Patch
-  type For3Use2_13 = sbt.librarymanagement.For3Use2_13
-  type For2_13Use3 = sbt.librarymanagement.For2_13Use3
 
   /** The first `major.minor` Scala version that the Scala binary version should be used for cross-versioning instead of the full version. */
   val TransitionScalaVersion = CrossVersionUtil.TransitionScalaVersion
@@ -86,6 +82,24 @@ private[librarymanagement] abstract class CrossVersionFunctions {
    * Always prepend `prefix` and append `suffix`
    */
   def for2_13Use3With(prefix: String, suffix: String): CrossVersion = For2_13Use3(prefix, suffix)
+
+  private[sbt] def getPrefixSuffix(value: CrossVersion): (String, String) =
+    value match {
+      case (_: Disabled | _: Constant | _: Patch) => ("", "")
+      case b: Binary                              => (b.prefix, b.suffix)
+      case f: Full                                => (f.prefix, f.suffix)
+      case c: For3Use2_13                         => (c.prefix, c.suffix)
+      case c: For2_13Use3                         => (c.prefix, c.suffix)
+    }
+
+  private[sbt] def setPrefixSuffix(value: CrossVersion, p: String, s: String): CrossVersion =
+    value match {
+      case (_: Disabled | _: Constant | _: Patch) => value
+      case b: Binary                              => b.withPrefix(p).withSuffix(s)
+      case f: Full                                => f.withPrefix(p).withSuffix(s)
+      case c: For3Use2_13                         => c.withPrefix(p).withSuffix(s)
+      case c: For2_13Use3                         => c.withPrefix(p).withSuffix(s)
+    }
 
   private[sbt] def patchFun(fullVersion: String): String = {
     val BinCompatV = """(\d+)\.(\d+)\.(\d+)(-\w+)??-bin(-.*)?""".r

--- a/core/src/test/scala/sbt/librarymanagement/ModuleIdTest.scala
+++ b/core/src/test/scala/sbt/librarymanagement/ModuleIdTest.scala
@@ -1,31 +1,49 @@
 package sbt.librarymanagement
 
-import sbt.internal.librarymanagement.UnitSpec
 import sjsonnew.support.scalajson.unsafe.{ Converter, CompactPrinter, Parser }
 
-class ModuleIdTest extends UnitSpec {
-  val expectedJson =
-    """{"organization":"com.acme","name":"foo","revision":"1","isChanging":false,"isTransitive":true,"isForce":false,"explicitArtifacts":[],"inclusions":[],"exclusions":[],"extraAttributes":{},"crossVersion":{"type":"Disabled"}}"""
-  "Module Id" should "return cross-disabled module id as equal to a copy" in {
-    ModuleID("com.acme", "foo", "1") shouldBe ModuleID("com.acme", "foo", "1")
+object ModuleIdTest extends verify.BasicTestSuite {
+  test("Module Id should return cross-disabled module id as equal to a copy") {
+    assert(ModuleID("com.acme", "foo", "1") == ModuleID("com.acme", "foo", "1"))
   }
-  it should "return cross-full module id as equal to a copy" in {
-    (ModuleID("com.acme", "foo", "1") cross CrossVersion.full) shouldBe
-      (ModuleID("com.acme", "foo", "1") cross CrossVersion.full)
+
+  test("it should return cross-full module id as equal to a copy") {
+    assert(
+      ModuleID("com.acme", "foo", "1").cross(CrossVersion.full) ==
+        ModuleID("com.acme", "foo", "1").cross(CrossVersion.full)
+    )
   }
-  it should "return cross-binary module id as equal to a copy" in {
-    (ModuleID("com.acme", "foo", "1") cross CrossVersion.binary) shouldBe
-      (ModuleID("com.acme", "foo", "1") cross CrossVersion.binary)
+
+  test("it should return cross-binary module id as equal to a copy") {
+    assert(
+      ModuleID("com.acme", "foo", "1").cross(CrossVersion.binary) ==
+        ModuleID("com.acme", "foo", "1").cross(CrossVersion.binary)
+    )
   }
-  it should "format itself into JSON" in {
+
+  test("it should format itself into JSON") {
     import LibraryManagementCodec._
     val json = Converter.toJson(ModuleID("com.acme", "foo", "1")).get
     assert(CompactPrinter(json) == expectedJson)
   }
-  it should "thaw back from JSON" in {
+
+  test("it should thaw back from JSON") {
     import LibraryManagementCodec._
     val json = Parser.parseUnsafe(expectedJson)
     val m = Converter.fromJsonUnsafe[ModuleID](json)
     assert(m == ModuleID("com.acme", "foo", "1"))
   }
+
+  test("cross(...) should compose prefix with the existing value") {
+    assert(
+      ModuleID("com.acme", "foo", "1")
+        .cross(CrossVersion.binaryWith("sjs1_", ""))
+        .cross(CrossVersion.for3Use2_13)
+        ==
+          ModuleID("com.acme", "foo", "1").cross(CrossVersion.for3Use2_13With("sjs1_", ""))
+    )
+  }
+
+  def expectedJson =
+    """{"organization":"com.acme","name":"foo","revision":"1","isChanging":false,"isTransitive":true,"isForce":false,"explicitArtifacts":[],"inclusions":[],"exclusions":[],"extraAttributes":{},"crossVersion":{"type":"Disabled"}}"""
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -53,7 +53,7 @@ object Dependencies {
   val scalaCompiler = Def.setting { "org.scala-lang" % "scala-compiler" % scalaVersion.value }
   val scalaXml = "org.scala-lang.modules" %% "scala-xml" % "1.2.0"
   val scalaTest = "org.scalatest" %% "scalatest" % "3.2.0"
-  val scalaVerify = "com.eed3si9n.verify" %% "verify" % "0.1.0"
+  val scalaVerify = "com.eed3si9n.verify" %% "verify" % "1.0.0"
   val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.14.0"
   val sjsonnew = Def.setting {
     "com.eed3si9n" %% "sjson-new-core" % contrabandSjsonNewVersion.value


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/6280

sbt-platform-deps implements `%%%` operator in https://github.com/portable-scala/sbt-platform-deps/blob/v1.0.0/src/main/scala/org/portablescala/sbtplatformdeps/PlatformDepsBuilders.scala#L36-L43
by setting the prefix field on `sbt.librarymanagement.Binary(...)`.
Currently `.cross(...)` would wipe this out, so `%%%` and `cross(CrossVersion.for3Use2_13)` do not compose.

This changes the implementation of `.cross(...)` so it can be chained
together and it will try to preserve the prefix (and suffix) values from
the existing `crossVersion` values.
This should fix the 2.13-3.x sandwich on Scala.JS and Scala Native.