### PR TITLE
FileCredentials without realm

### DIFF
--- a/ivy/src/main/scala/sbt/librarymanagement/ivy/Credentials.scala
+++ b/ivy/src/main/scala/sbt/librarymanagement/ivy/Credentials.scala
@@ -47,9 +47,13 @@ object Credentials {
           .headOption
           .toRight(keys.head + " not specified in credentials file: " + path)
 
-      IvyUtil.separate(List(RealmKeys, HostKeys, UserKeys, PasswordKeys).map(get)) match {
-        case (Nil, List(realm, host, user, pass)) =>
-          Right(new DirectCredentials(realm, host, user, pass))
+      IvyUtil.separate(List(HostKeys, UserKeys, PasswordKeys).map(get)) match {
+        case (Nil, List(host, user, pass)) =>
+          IvyUtil.separate(List(RealmKeys).map(get)) match {
+            case (_, List(realm)) => Right(new DirectCredentials(realm, host, user, pass))
+            case _                => Right(new DirectCredentials(null, host, user, pass))
+          }
+
         case (errors, _) => Left(errors.mkString("\n"))
       }
     } else

--- a/ivy/src/test/scala/sbt/internal/librarymanagement/CredentialsSpec.scala
+++ b/ivy/src/test/scala/sbt/internal/librarymanagement/CredentialsSpec.scala
@@ -1,0 +1,28 @@
+package sbt.internal.librarymanagement
+
+import sbt.librarymanagement.ivy.Credentials
+
+import java.io.File
+import java.nio.file.Files
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class CredentialsSpec extends AnyFunSuite {
+
+  test("load credential file without authentication") {
+    val credentialsFile = File.createTempFile("credentials", "tmp")
+
+    val content =
+      """|host=example.org
+         |user=username
+         |password=password""".stripMargin
+
+    Files.write(credentialsFile.toPath(), content.getBytes())
+
+    val Right(credentials) = Credentials.loadCredentials(credentialsFile)
+
+    assert(credentials.realm == null)
+
+    credentialsFile.delete()
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/6362

```
host=example.org
user=username
password=password
```
