### PR TITLE
Specify dependencies of plugins that handles custom protocols

### DIFF
--- a/core/src/main/contraband-scala/sbt/librarymanagement/LibraryManagementCodec.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/LibraryManagementCodec.scala
@@ -10,7 +10,6 @@ trait LibraryManagementCodec extends sjsonnew.BasicJsonProtocol
   with sbt.librarymanagement.UpdateLoggingFormats
   with sbt.internal.librarymanagement.formats.LogicalClockFormats
   with sbt.librarymanagement.ArtifactTypeFilterFormats
-  with sbt.librarymanagement.UpdateConfigurationFormats
   with sbt.librarymanagement.ChecksumFormats
   with sbt.librarymanagement.ArtifactFormats
   with sbt.librarymanagement.CrossVersionFormats
@@ -23,6 +22,7 @@ trait LibraryManagementCodec extends sjsonnew.BasicJsonProtocol
   with sbt.librarymanagement.For2_13Use3Formats
   with sbt.librarymanagement.InclExclRuleFormats
   with sbt.librarymanagement.ModuleIDFormats
+  with sbt.librarymanagement.UpdateConfigurationFormats
   with sbt.librarymanagement.ConfigurationFormats
   with sbt.librarymanagement.ScalaModuleInfoFormats
   with sbt.librarymanagement.GetClassifiersModuleFormats

--- a/core/src/main/contraband-scala/sbt/librarymanagement/UpdateConfiguration.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/UpdateConfiguration.scala
@@ -12,6 +12,7 @@ package sbt.librarymanagement
  * @param logging Logging setting used specifially for library management.
  * @param logicalClock The clock that may be used for caching.
  * @param metadataDirectory The base directory that may be used to store metadata.
+ * @param protocolHandlerDependencies Dependencies to load to handle custom protocols for dependency resolution
  */
 final class UpdateConfiguration private (
   val retrieveManaged: Option[sbt.librarymanagement.RetrieveConfiguration],
@@ -21,22 +22,24 @@ final class UpdateConfiguration private (
   val metadataDirectory: Option[java.io.File],
   val artifactFilter: Option[sbt.librarymanagement.ArtifactTypeFilter],
   val offline: Boolean,
-  val frozen: Boolean) extends Serializable {
+  val frozen: Boolean,
+  val protocolHandlerDependencies: Vector[sbt.librarymanagement.ModuleID]) extends Serializable {
   
-  private def this() = this(None, false, sbt.librarymanagement.UpdateLogging.Default, sbt.librarymanagement.LogicalClock.unknown, None, None, false, false)
+  private def this() = this(None, false, sbt.librarymanagement.UpdateLogging.Default, sbt.librarymanagement.LogicalClock.unknown, None, None, false, false, Vector.empty)
+  private def this(retrieveManaged: Option[sbt.librarymanagement.RetrieveConfiguration], missingOk: Boolean, logging: sbt.librarymanagement.UpdateLogging, logicalClock: sbt.librarymanagement.LogicalClock, metadataDirectory: Option[java.io.File], artifactFilter: Option[sbt.librarymanagement.ArtifactTypeFilter], offline: Boolean, frozen: Boolean) = this(retrieveManaged, missingOk, logging, logicalClock, metadataDirectory, artifactFilter, offline, frozen, Vector.empty)
   
   override def equals(o: Any): Boolean = this.eq(o.asInstanceOf[AnyRef]) || (o match {
-    case x: UpdateConfiguration => (this.retrieveManaged == x.retrieveManaged) && (this.missingOk == x.missingOk) && (this.logging == x.logging) && (this.logicalClock == x.logicalClock) && (this.metadataDirectory == x.metadataDirectory) && (this.artifactFilter == x.artifactFilter) && (this.offline == x.offline) && (this.frozen == x.frozen)
+    case x: UpdateConfiguration => (this.retrieveManaged == x.retrieveManaged) && (this.missingOk == x.missingOk) && (this.logging == x.logging) && (this.logicalClock == x.logicalClock) && (this.metadataDirectory == x.metadataDirectory) && (this.artifactFilter == x.artifactFilter) && (this.offline == x.offline) && (this.frozen == x.frozen) && (this.protocolHandlerDependencies == x.protocolHandlerDependencies)
     case _ => false
   })
   override def hashCode: Int = {
-    37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (17 + "sbt.librarymanagement.UpdateConfiguration".##) + retrieveManaged.##) + missingOk.##) + logging.##) + logicalClock.##) + metadataDirectory.##) + artifactFilter.##) + offline.##) + frozen.##)
+    37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (17 + "sbt.librarymanagement.UpdateConfiguration".##) + retrieveManaged.##) + missingOk.##) + logging.##) + logicalClock.##) + metadataDirectory.##) + artifactFilter.##) + offline.##) + frozen.##) + protocolHandlerDependencies.##)
   }
   override def toString: String = {
-    "UpdateConfiguration(" + retrieveManaged + ", " + missingOk + ", " + logging + ", " + logicalClock + ", " + metadataDirectory + ", " + artifactFilter + ", " + offline + ", " + frozen + ")"
+    "UpdateConfiguration(" + retrieveManaged + ", " + missingOk + ", " + logging + ", " + logicalClock + ", " + metadataDirectory + ", " + artifactFilter + ", " + offline + ", " + frozen + ", " + protocolHandlerDependencies + ")"
   }
-  private[this] def copy(retrieveManaged: Option[sbt.librarymanagement.RetrieveConfiguration] = retrieveManaged, missingOk: Boolean = missingOk, logging: sbt.librarymanagement.UpdateLogging = logging, logicalClock: sbt.librarymanagement.LogicalClock = logicalClock, metadataDirectory: Option[java.io.File] = metadataDirectory, artifactFilter: Option[sbt.librarymanagement.ArtifactTypeFilter] = artifactFilter, offline: Boolean = offline, frozen: Boolean = frozen): UpdateConfiguration = {
-    new UpdateConfiguration(retrieveManaged, missingOk, logging, logicalClock, metadataDirectory, artifactFilter, offline, frozen)
+  private[this] def copy(retrieveManaged: Option[sbt.librarymanagement.RetrieveConfiguration] = retrieveManaged, missingOk: Boolean = missingOk, logging: sbt.librarymanagement.UpdateLogging = logging, logicalClock: sbt.librarymanagement.LogicalClock = logicalClock, metadataDirectory: Option[java.io.File] = metadataDirectory, artifactFilter: Option[sbt.librarymanagement.ArtifactTypeFilter] = artifactFilter, offline: Boolean = offline, frozen: Boolean = frozen, protocolHandlerDependencies: Vector[sbt.librarymanagement.ModuleID] = protocolHandlerDependencies): UpdateConfiguration = {
+    new UpdateConfiguration(retrieveManaged, missingOk, logging, logicalClock, metadataDirectory, artifactFilter, offline, frozen, protocolHandlerDependencies)
   }
   def withRetrieveManaged(retrieveManaged: Option[sbt.librarymanagement.RetrieveConfiguration]): UpdateConfiguration = {
     copy(retrieveManaged = retrieveManaged)
@@ -71,10 +74,15 @@ final class UpdateConfiguration private (
   def withFrozen(frozen: Boolean): UpdateConfiguration = {
     copy(frozen = frozen)
   }
+  def withProtocolHandlerDependencies(protocolHandlerDependencies: Vector[sbt.librarymanagement.ModuleID]): UpdateConfiguration = {
+    copy(protocolHandlerDependencies = protocolHandlerDependencies)
+  }
 }
 object UpdateConfiguration {
   
   def apply(): UpdateConfiguration = new UpdateConfiguration()
   def apply(retrieveManaged: Option[sbt.librarymanagement.RetrieveConfiguration], missingOk: Boolean, logging: sbt.librarymanagement.UpdateLogging, logicalClock: sbt.librarymanagement.LogicalClock, metadataDirectory: Option[java.io.File], artifactFilter: Option[sbt.librarymanagement.ArtifactTypeFilter], offline: Boolean, frozen: Boolean): UpdateConfiguration = new UpdateConfiguration(retrieveManaged, missingOk, logging, logicalClock, metadataDirectory, artifactFilter, offline, frozen)
   def apply(retrieveManaged: sbt.librarymanagement.RetrieveConfiguration, missingOk: Boolean, logging: sbt.librarymanagement.UpdateLogging, logicalClock: sbt.librarymanagement.LogicalClock, metadataDirectory: java.io.File, artifactFilter: sbt.librarymanagement.ArtifactTypeFilter, offline: Boolean, frozen: Boolean): UpdateConfiguration = new UpdateConfiguration(Option(retrieveManaged), missingOk, logging, logicalClock, Option(metadataDirectory), Option(artifactFilter), offline, frozen)
+  def apply(retrieveManaged: Option[sbt.librarymanagement.RetrieveConfiguration], missingOk: Boolean, logging: sbt.librarymanagement.UpdateLogging, logicalClock: sbt.librarymanagement.LogicalClock, metadataDirectory: Option[java.io.File], artifactFilter: Option[sbt.librarymanagement.ArtifactTypeFilter], offline: Boolean, frozen: Boolean, protocolHandlerDependencies: Vector[sbt.librarymanagement.ModuleID]): UpdateConfiguration = new UpdateConfiguration(retrieveManaged, missingOk, logging, logicalClock, metadataDirectory, artifactFilter, offline, frozen, protocolHandlerDependencies)
+  def apply(retrieveManaged: sbt.librarymanagement.RetrieveConfiguration, missingOk: Boolean, logging: sbt.librarymanagement.UpdateLogging, logicalClock: sbt.librarymanagement.LogicalClock, metadataDirectory: java.io.File, artifactFilter: sbt.librarymanagement.ArtifactTypeFilter, offline: Boolean, frozen: Boolean, protocolHandlerDependencies: Vector[sbt.librarymanagement.ModuleID]): UpdateConfiguration = new UpdateConfiguration(Option(retrieveManaged), missingOk, logging, logicalClock, Option(metadataDirectory), Option(artifactFilter), offline, frozen, protocolHandlerDependencies)
 }

--- a/core/src/main/contraband-scala/sbt/librarymanagement/UpdateConfigurationFormats.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/UpdateConfigurationFormats.scala
@@ -5,7 +5,7 @@
 // DO NOT EDIT MANUALLY
 package sbt.librarymanagement
 import _root_.sjsonnew.{ Unbuilder, Builder, JsonFormat, deserializationError }
-trait UpdateConfigurationFormats { self: sbt.librarymanagement.RetrieveConfigurationFormats with sbt.librarymanagement.UpdateLoggingFormats with sbt.internal.librarymanagement.formats.LogicalClockFormats with sbt.librarymanagement.ArtifactTypeFilterFormats with sjsonnew.BasicJsonProtocol =>
+trait UpdateConfigurationFormats { self: sbt.librarymanagement.RetrieveConfigurationFormats with sbt.librarymanagement.UpdateLoggingFormats with sbt.internal.librarymanagement.formats.LogicalClockFormats with sbt.librarymanagement.ArtifactTypeFilterFormats with sbt.librarymanagement.ModuleIDFormats with sjsonnew.BasicJsonProtocol =>
 implicit lazy val UpdateConfigurationFormat: JsonFormat[sbt.librarymanagement.UpdateConfiguration] = new JsonFormat[sbt.librarymanagement.UpdateConfiguration] {
   override def read[J](__jsOpt: Option[J], unbuilder: Unbuilder[J]): sbt.librarymanagement.UpdateConfiguration = {
     __jsOpt match {
@@ -19,8 +19,9 @@ implicit lazy val UpdateConfigurationFormat: JsonFormat[sbt.librarymanagement.Up
       val artifactFilter = unbuilder.readField[Option[sbt.librarymanagement.ArtifactTypeFilter]]("artifactFilter")
       val offline = unbuilder.readField[Boolean]("offline")
       val frozen = unbuilder.readField[Boolean]("frozen")
+      val protocolHandlerDependencies = unbuilder.readField[Vector[sbt.librarymanagement.ModuleID]]("protocolHandlerDependencies")
       unbuilder.endObject()
-      sbt.librarymanagement.UpdateConfiguration(retrieveManaged, missingOk, logging, logicalClock, metadataDirectory, artifactFilter, offline, frozen)
+      sbt.librarymanagement.UpdateConfiguration(retrieveManaged, missingOk, logging, logicalClock, metadataDirectory, artifactFilter, offline, frozen, protocolHandlerDependencies)
       case None =>
       deserializationError("Expected JsObject but found None")
     }
@@ -35,6 +36,7 @@ implicit lazy val UpdateConfigurationFormat: JsonFormat[sbt.librarymanagement.Up
     builder.addField("artifactFilter", obj.artifactFilter)
     builder.addField("offline", obj.offline)
     builder.addField("frozen", obj.frozen)
+    builder.addField("protocolHandlerDependencies", obj.protocolHandlerDependencies)
     builder.endObject()
   }
 }

--- a/core/src/main/contraband/librarymanagement.json
+++ b/core/src/main/contraband/librarymanagement.json
@@ -67,6 +67,15 @@
           "type": "boolean",
           "default": "false",
           "since": "0.0.1"
+        },
+        {
+          "name": "protocolHandlerDependencies",
+          "doc": [
+            "Dependencies to load to handle custom protocols for dependency resolution"
+          ],
+          "type": "sbt.librarymanagement.ModuleID*", 
+          "default": "Vector.empty", 
+          "since": "1.5.0-M5"
         }
       ]
     },


### PR DESCRIPTION
In coursier, you can handle custom protocols by defining a protocol handler:
https://get-coursier.io/docs/2.0.10/extra.html#extra-protocols
https://github.com/coursier/coursier/blob/ce251d0288bf029e4eeb8700e8990178559a005d/modules/tests/jvm/src/test/scala/coursier/cache/protocol/TestprotocolHandler.scala

I'm currently implementing support for Google Aritfactr Resitory:
https://github.com/coursier/coursier/issues/1987#issuecomment-792894989

When dealing with artifact with protocol `artifactregistry` I need to have a plugin available in the classpath. Since lmcoursier is in the sbt launcher classpath, it's not available by adding `libraryDependencies += ...` in `project/plugins.sbt` like you would do for an sbt plugin. Therefore, I propose a way to explicitly declare the artifacts you need to handle the protocol handling.