### PR TITLE
Fix binary version of 3.0.1-RC1

### DIFF
--- a/core/src/main/scala/sbt/internal/librarymanagement/cross/CrossVersionUtil.scala
+++ b/core/src/main/scala/sbt/internal/librarymanagement/cross/CrossVersionUtil.scala
@@ -75,11 +75,11 @@ object CrossVersionUtil {
     }
 
   private[sbt] def binaryScala3Version(full: String): String = full match {
-    case ReleaseV(maj, _, _, _)                       => maj
-    case CandidateV(maj, min, _, _) if min.toLong > 0 => maj
-    case MilestonV(maj, min, _, _) if min.toLong > 0  => maj
-    case BinCompatV(maj, min, patch, stage, _)        => binaryScala3Version(s"$maj.$min.$patch$stage")
-    case _                                            => full
+    case ReleaseV(maj, _, _, _)                                               => maj
+    case CandidateV(maj, min, patch, _) if min.toLong > 0 || patch.toLong > 0 => maj
+    case MilestonV(maj, min, patch, _) if min.toLong > 0 || patch.toLong > 0  => maj
+    case BinCompatV(maj, min, patch, stage, _)                                => binaryScala3Version(s"$maj.$min.$patch$stage")
+    case _                                                                    => full
   }
 
   def binaryScalaVersion(full: String): String = {

--- a/core/src/test/scala/sbt/librarymanagement/CrossVersionTest.scala
+++ b/core/src/test/scala/sbt/librarymanagement/CrossVersionTest.scala
@@ -237,6 +237,15 @@ class CrossVersionTest extends UnitSpec {
   it should "for 3.1.0 return 3" in {
     binaryScalaVersion("3.1.0") shouldBe "3"
   }
+  it should "for 3.0.1-RC1 return 3" in {
+    binaryScalaVersion("3.0.1-RC1") shouldBe "3"
+  }
+  it should "for 3.0.1-M1 return 3" in {
+    binaryScalaVersion("3.0.1-M1") shouldBe "3"
+  }
+  it should "for 3.0.1-RC1-bin-SNAPSHOT return 3" in {
+    binaryScalaVersion("3.0.1-RC1") shouldBe "3"
+  }
 
   private def patchVersion(fullVersion: String) =
     CrossVersion(CrossVersion.patch, fullVersion, "dummy") map (fn => fn("artefact"))


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/6420

`scalaBinaryVersion` of `3.0.1-RC1` should be `3`