### PR TITLE
Fixes sbt/sbt#6496 - bug in version parser

### DIFF
--- a/core/src/main/scala/sbt/librarymanagement/VersionNumber.scala
+++ b/core/src/main/scala/sbt/librarymanagement/VersionNumber.scala
@@ -66,7 +66,7 @@ object VersionNumber {
     def splitDash(s: String) = splitOn(s, '-')
     def splitPlus(s: String) = splitOn(s, '+') map ("+" + _)
 
-    val TaggedVersion = """(\d{1,14})([\.\d{1,14}]*)((?:-\w+)*)((?:\+.+)*)""".r
+    val TaggedVersion = """(\d{1,14})([\.\d{1,14}]*)((?:-[\w\.]+)*)((?:\+.+)*)""".r
     val NonSpaceString = """(\S+)""".r
 
     s match {

--- a/core/src/test/scala/sbt/librarymanagement/VersionNumberSpec.scala
+++ b/core/src/test/scala/sbt/librarymanagement/VersionNumberSpec.scala
@@ -97,6 +97,13 @@ class VersionNumberSpec extends AnyFreeSpec with Matchers with Inside {
     assertCascadesTo(v, Seq("0.1.0-MSERVER-1", "0.1.0", "0.1"))
   }
 
+  version("1.1.0-DLP-7923-presigned-download-url.5") { v =>
+    assertParsesTo(v, Seq(1, 1, 0), Seq("DLP", "7923", "presigned", "download", "url.5"), Seq())
+    assertCascadesTo(v, Seq("1.1.0-DLP-7923-presigned-download-url.5", "1.1.0", "1.1"))
+    assertIsCompatibleWith(v, "1.0.7", EarlySemVer)
+    assertIsNotCompatibleWith(v, "1.0.7", PackVer)
+  }
+
   version("2.10.4-20140115-000117-b3a-sources") { v =>
     assertParsesTo(v, Seq(2, 10, 4), Seq("20140115", "000117", "b3a", "sources"), Seq())
     assertCascadesTo(v, Seq("2.10.4-20140115-000117-b3a-sources", "2.10.4", "2.10"))


### PR DESCRIPTION
## What is the problem?
sbt/sbt#6496 identifies a bug in the logic which assesses whether different versions of the same transitive dependency are binary compatible. 

If one of the transitive dependencies included a version with a full-stop literal, it would be parsed incorrectly and an error would be thrown to the user falsely saying that the dependencies are binary incompatible.

## What is the solution?
This PR fixes the regex used by the parser to include full-stop literals.

## Is there anything else to be done?
It is worth us checking the rest of the codebase in case this bug might exist in other parsing functions. The tests are super helpful for figuring out which strings might break the current logic 👍🏽.