### PR TITLE
Expand allowed maven repository id characters to match maven

### DIFF
--- a/ivy/src/main/scala/sbt/internal/librarymanagement/MakePom.scala
+++ b/ivy/src/main/scala/sbt/internal/librarymanagement/MakePom.scala
@@ -504,7 +504,7 @@ class MakePom(val log: Logger) {
     s.toArray.map(_.asInstanceOf[DependencyResolver])
 
   def toID(name: String) = checkID(name.filter(isValidIDCharacter).mkString, name)
-  def isValidIDCharacter(c: Char) = """\/:"<>|?*""".contains(c)
+  def isValidIDCharacter(c: Char) = !"""\/:"<>|?*""".contains(c)
   private def checkID(id: String, name: String) =
     if (id.isEmpty) sys.error("Could not convert '" + name + "' to an ID") else id
   def mavenRepository(repo: MavenRepository): XNode =

--- a/ivy/src/main/scala/sbt/internal/librarymanagement/MakePom.scala
+++ b/ivy/src/main/scala/sbt/internal/librarymanagement/MakePom.scala
@@ -504,7 +504,7 @@ class MakePom(val log: Logger) {
     s.toArray.map(_.asInstanceOf[DependencyResolver])
 
   def toID(name: String) = checkID(name.filter(isValidIDCharacter).mkString, name)
-  def isValidIDCharacter(c: Char) = c.isLetterOrDigit
+  def isValidIDCharacter(c: Char) = """\/:"<>|?*""".contains(c)
   private def checkID(id: String, name: String) =
     if (id.isEmpty) sys.error("Could not convert '" + name + "' to an ID") else id
   def mavenRepository(repo: MavenRepository): XNode =

--- a/ivy/src/test/scala/sbt/internal/librarymanagement/MakePomSpec.scala
+++ b/ivy/src/test/scala/sbt/internal/librarymanagement/MakePomSpec.scala
@@ -1,6 +1,7 @@
 package sbt.internal.librarymanagement
 
 import sbt.internal.util.ConsoleLogger
+import sbt.librarymanagement.MavenRepository
 import verify.BasicTestSuite
 
 // http://ant.apache.org/ivy/history/2.3.0/ivyfile/dependency.html
@@ -72,6 +73,18 @@ object MakePomSpec extends BasicTestSuite {
 
   test("foo+ should convert to foo+") {
     beParsedAsError("foo+")
+  }
+
+  test("repository id should not contain maven illegal repo id characters") {
+    val repository = mp.mavenRepository(
+      MavenRepository(
+        """repository-id-\with-/illegal:"<-chars>|?*-others~!@#$%^&`';{}[]=+_,.""",
+        "uri"
+      )
+    )
+    assert(
+      (repository \ "id").text == "repository-id-with-illegal-chars-others~!@#$%^&`';{}[]=+_,."
+    )
   }
 
   val mp = new MakePom(ConsoleLogger())


### PR DESCRIPTION
fixes sbt/sbt#1608

see https://github.com/apache/maven/blob/5c45b3fe22d8ec4270b2cf1016581b8927d2913d/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java#L84