### PR TITLE
Fix cross-Scala suffix conflict warning

### DIFF
--- a/core/src/main/scala/sbt/librarymanagement/ConflictWarning.scala
+++ b/core/src/main/scala/sbt/librarymanagement/ConflictWarning.scala
@@ -59,7 +59,7 @@ object ConflictWarning {
   private[this] def groupByRawName(ms: Seq[ModuleID]): Map[(String, String), Seq[ModuleID]] =
     ms.groupBy(m => (m.organization, dropCrossSuffix(m.name)))
 
-  private[this] val CrossSuffixPattern = """(.+)_(\d+\.\d+(?:\.\d+)?(?:-.+)?)""".r
+  private[this] val CrossSuffixPattern = """(.+)_(\d+(?:\.\d+)?(?:\.\d+)?(?:-.+)?)""".r
   private[this] def dropCrossSuffix(s: String): String = s match {
     case CrossSuffixPattern(raw, _) => raw
     case _                          => s

--- a/ivy/src/test/scala/sbt/internal/librarymanagement/ConflictWarningSpec.scala
+++ b/ivy/src/test/scala/sbt/internal/librarymanagement/ConflictWarningSpec.scala
@@ -1,0 +1,40 @@
+package sbt.internal.librarymanagement
+
+import sbt.librarymanagement._
+import sbt.librarymanagement.syntax._
+
+object ConflictWarningSpec extends BaseIvySpecification {
+
+  test("it should print out message about the cross-Scala conflict") {
+    var found = false
+    val deps = Vector(
+      `scala2.13.6`,
+      `cats-effect3.1.1`,
+      `cats-core2.6.1`.cross(CrossVersion.for3Use2_13),
+    )
+    val m = module(defaultModuleId, deps, Some("3.0.1-RC2"))
+    val report = ivyUpdate(m)
+    val w = ConflictWarning.default("foo")
+
+    try {
+      ConflictWarning(w, report, log)
+    } catch {
+      case e: Throwable =>
+        found = true
+        assert(
+          e.getMessage.linesIterator.toList.head
+            .startsWith("Conflicting cross-version suffixes in")
+        )
+    }
+    if (!found) {
+      sys.error("conflict warning was expected, but didn't happen sbt/sbt#6578")
+    }
+  }
+
+  lazy val `scala2.13.6` =
+    ModuleID("org.scala-lang", "scala-library", "2.13.6").withConfigurations(Some("compile"))
+  lazy val `cats-effect3.1.1` =
+    ("org.typelevel" %% "cats-effect" % "3.1.1").withConfigurations(Some("compile"))
+  lazy val `cats-core2.6.1` =
+    ("org.typelevel" %% "cats-core" % "2.6.1").withConfigurations(Some("compile"))
+}


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/6578

Problem
-------
The regex currently expects two segments like2.x or 3.x,
but Scala 3 uses _3 as the cross suffix, and it's not caught.

Solution
--------
Change the regex.