### PR TITLE
Fix Scala 3 binary version

### DIFF
--- a/core/src/main/scala/sbt/internal/librarymanagement/cross/CrossVersionUtil.scala
+++ b/core/src/main/scala/sbt/internal/librarymanagement/cross/CrossVersionUtil.scala
@@ -76,11 +76,12 @@ object CrossVersionUtil {
     }
 
   private[sbt] def binaryScala3Version(full: String): String = full match {
-    case ReleaseV(maj, _, _, _)                                               => maj
-    case CandidateV(maj, min, patch, _) if min.toLong > 0 || patch.toLong > 0 => maj
-    case MilestonV(maj, min, patch, _) if min.toLong > 0 || patch.toLong > 0  => maj
-    case BinCompatV(maj, min, patch, stage, _)                                => binaryScala3Version(s"$maj.$min.$patch$stage")
-    case _                                                                    => full
+    case ReleaseV(maj, _, _, _)                                                  => maj
+    case NonReleaseV_n(maj, min, patch, _) if min.toLong > 0 || patch.toLong > 0 => maj
+    case BinCompatV(maj, min, patch, stageOrNull, _) =>
+      val stage = if (stageOrNull != null) stageOrNull else ""
+      binaryScala3Version(s"$maj.$min.$patch$stage")
+    case _ => full
   }
 
   def binaryScalaVersion(full: String): String = {

--- a/core/src/test/scala/sbt/librarymanagement/CrossVersionTest.scala
+++ b/core/src/test/scala/sbt/librarymanagement/CrossVersionTest.scala
@@ -250,7 +250,13 @@ class CrossVersionTest extends UnitSpec {
     binaryScalaVersion("3.0.1-M1") shouldBe "3"
   }
   it should "for 3.0.1-RC1-bin-SNAPSHOT return 3" in {
-    binaryScalaVersion("3.0.1-RC1") shouldBe "3"
+    binaryScalaVersion("3.0.1-RC1-bin-SNAPSHOT") shouldBe "3"
+  }
+  it should "for 3.0.1-bin-nonbootstrapped return 3" in {
+    binaryScalaVersion("3.0.1-bin-SNAPSHOT") shouldBe "3"
+  }
+  it should "for 3.0.1-SNAPSHOT return 3" in {
+    binaryScalaVersion("3.0.1-SNAPSHOT") shouldBe "3"
   }
 
   private def patchVersion(fullVersion: String) =


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/6585

The binary version of `3.x.y-foo-bar` should be `3` if x > 0 or  y > 0.

Example: 
- for `3.0.1-bin-nonbootstrapped` it should be `3`
- for `3.0.1-SNAPSHOT` it should be `3`

@smarter @prolativ