### PR TITLE
Avoid repeating versions in Eviction error message

### DIFF
--- a/core/src/main/scala/sbt/librarymanagement/EvictionError.scala
+++ b/core/src/main/scala/sbt/librarymanagement/EvictionError.scala
@@ -155,7 +155,8 @@ final class EvictionError private[sbt] (
     evictions.foreach({
       case (a, scheme) =>
         val revs = a.evicteds map { _.module.revision }
-        val revsStr = if (revs.size <= 1) revs.mkString else "{" + revs.mkString(", ") + "}"
+        val revsStr =
+          if (revs.size <= 1) revs.mkString else "{" + revs.distinct.mkString(", ") + "}"
         val seen: mutable.Set[ModuleID] = mutable.Set()
         val callers: List[String] = (a.evicteds.toList ::: a.winner.toList) flatMap { r =>
           val rev = r.module.revision


### PR DESCRIPTION
Currently the evicted version numbers can be repeated many times:

> [error] 	* org.scala-lang.modules:scala-java8-compat_2.13:1.0.0 (early-semver) is selected over {0.9.0, 0.9.0, 0.9.0, 0.9.0, 0.9.1, 0.9.1, 0.9.1}

This change makes for a clearer message by removing that unnecessary noisy repetition:

> [error]         * org.scala-lang.modules:scala-java8-compat_2.13:1.0.0 (early-semver) is selected over {0.9.0, 0.9.1}

Thanks!