### PR TITLE
Respect maven.repo.local property

### DIFF
--- a/core/src/main/scala/sbt/librarymanagement/ResolverExtra.scala
+++ b/core/src/main/scala/sbt/librarymanagement/ResolverExtra.scala
@@ -392,7 +392,8 @@ private[librarymanagement] abstract class ResolverFunctions {
           System.err.println(s"WARNING: Problem parsing ${f().getAbsolutePath}, ${e.getMessage}");
           None
       }
-    loadHomeFromSettings(() => new File(sbt.io.Path.userHome, ".m2/settings.xml")) orElse
+    sys.props.get("maven.repo.local").map(new File(_)) orElse
+      loadHomeFromSettings(() => new File(sbt.io.Path.userHome, ".m2/settings.xml")) orElse
       loadHomeFromSettings(() => new File(new File(System.getenv("M2_HOME")), "conf/settings.xml")) getOrElse
       new File(sbt.io.Path.userHome, ".m2/repository")
   }


### PR DESCRIPTION
The local repository location is derived from the maven settings.xml. However there is also the `maven.repo.local` system property to override this ([docs](https://maven.apache.org/ref/3.8.4/maven-model-builder/index.html)). It would be nice if sbt would respect this. 
The content of this pull request is a naive approach. Happy to receive some feedback.