### PR TITLE
Deprecate `sonatypeRepo`, add `sonatypeOssRepos` to `Resolver`

### DIFF
--- a/core/src/main/scala/sbt/librarymanagement/ResolverExtra.scala
+++ b/core/src/main/scala/sbt/librarymanagement/ResolverExtra.scala
@@ -155,7 +155,7 @@ private[librarymanagement] abstract class ResolverFunctions {
     url("sbt-plugin-" + status, new URL(SbtRepositoryRoot + "/sbt-plugin-" + status + "/"))(
       ivyStylePatterns
     )
-  @deprecated("Use sonatypeRepos instead", "1.7.0")
+  @deprecated("Use sonatypeOssRepos instead", "1.7.0")
   def sonatypeRepo(status: String) =
     MavenRepository(
       "sonatype-" + status,
@@ -167,7 +167,7 @@ private[librarymanagement] abstract class ResolverFunctions {
       "sonatype-s01-" + status,
       SonatypeS01RepositoryRoot + "/" + status
     )
-  def sonatypeRepos(status: String) =
+  def sonatypeOssRepos(status: String) =
     Vector(sonatypeRepo(status): @nowarn("cat=deprecation"), sonatypeS01Repo(status))
   def bintrayRepo(owner: String, repo: String) =
     MavenRepository(s"bintray-$owner-$repo", s"https://dl.bintray.com/$owner/$repo/")

--- a/core/src/main/scala/sbt/librarymanagement/ResolverExtra.scala
+++ b/core/src/main/scala/sbt/librarymanagement/ResolverExtra.scala
@@ -5,6 +5,7 @@ package sbt.librarymanagement
 
 import java.io.{ IOException, File }
 import java.net.{ URI, URL }
+import scala.annotation.nowarn
 import scala.xml.XML
 import org.xml.sax.SAXParseException
 import sbt.util.Logger
@@ -154,17 +155,20 @@ private[librarymanagement] abstract class ResolverFunctions {
     url("sbt-plugin-" + status, new URL(SbtRepositoryRoot + "/sbt-plugin-" + status + "/"))(
       ivyStylePatterns
     )
+  @deprecated("Use sonatypeRepos instead", "1.7.0")
   def sonatypeRepo(status: String) =
     MavenRepository(
       "sonatype-" + status,
       if (status == "releases") SonatypeReleasesRepository
       else SonatypeRepositoryRoot + "/" + status
     )
-  def sonatypeS01Repo(status: String) =
+  private def sonatypeS01Repo(status: String) =
     MavenRepository(
       "sonatype-s01-" + status,
       SonatypeS01RepositoryRoot + "/" + status
     )
+  def sonatypeRepos(status: String) =
+    Vector(sonatypeRepo(status): @nowarn("cat=deprecation"), sonatypeS01Repo(status))
   def bintrayRepo(owner: String, repo: String) =
     MavenRepository(s"bintray-$owner-$repo", s"https://dl.bintray.com/$owner/$repo/")
   def bintrayIvyRepo(owner: String, repo: String) =

--- a/core/src/main/scala/sbt/librarymanagement/ResolverExtra.scala
+++ b/core/src/main/scala/sbt/librarymanagement/ResolverExtra.scala
@@ -102,6 +102,7 @@ private[librarymanagement] abstract class ResolverFunctions {
   @deprecated("Renamed to SbtRepositoryRoot.", "1.0.0")
   val SbtPluginRepositoryRoot = SbtRepositoryRoot
   val SonatypeRepositoryRoot = "https://oss.sonatype.org/content/repositories"
+  val SonatypeS01RepositoryRoot = "https://s01.oss.sonatype.org/content/repositories"
   val SonatypeReleasesRepository =
     "https://oss.sonatype.org/service/local/repositories/releases/content/"
   val JavaNet2RepositoryName = "java.net Maven2 Repository"
@@ -158,6 +159,11 @@ private[librarymanagement] abstract class ResolverFunctions {
       "sonatype-" + status,
       if (status == "releases") SonatypeReleasesRepository
       else SonatypeRepositoryRoot + "/" + status
+    )
+  def sonatypeS01Repo(status: String) =
+    MavenRepository(
+      "sonatype-s01-" + status,
+      SonatypeS01RepositoryRoot + "/" + status
     )
   def bintrayRepo(owner: String, repo: String) =
     MavenRepository(s"bintray-$owner-$repo", s"https://dl.bintray.com/$owner/$repo/")


### PR DESCRIPTION
Riffing on https://github.com/sbt/librarymanagement/pull/392#issuecomment-1013844695.

Since sonatype has indicated they may/will add additional hosts, this seems like the most sensible way forward.

> we can always cap subscribership on https://s01.oss.sonatype.org at a level that ensures peak performance and spin up yet another new host to handle future load.

https://central.sonatype.org/news/20210223_new-users-on-s01/#why-are-we-doing-this