### PR TITLE
Fix isScalaBinaryCompatibleWith

### DIFF
--- a/core/src/main/scala/sbt/internal/librarymanagement/cross/CrossVersionUtil.scala
+++ b/core/src/main/scala/sbt/internal/librarymanagement/cross/CrossVersionUtil.scala
@@ -94,8 +94,10 @@ object CrossVersionUtil {
   //
   private[sbt] def isScalaBinaryCompatibleWith(newVersion: String, origVersion: String): Boolean = {
     (newVersion, origVersion) match {
-      case (NonReleaseV_n("2", nMin, _, _), NonReleaseV_n("2", oMin, _, _)) =>
-        nMin == oMin
+      case (NonReleaseV_n("2", _, _, _), NonReleaseV_n("2", _, _, _)) =>
+        val api1 = scalaApiVersion(newVersion)
+        val api2 = scalaApiVersion(origVersion)
+        (api1.isDefined && api1 == api2) || (newVersion == origVersion)
       case (ReleaseV(nMaj, nMin, _, _), ReleaseV(oMaj, oMin, _, _))
           if nMaj == oMaj && nMaj.toLong >= 3 =>
         nMin.toInt >= oMin.toInt

--- a/core/src/test/scala/sbt/librarymanagement/CrossVersionTest.scala
+++ b/core/src/test/scala/sbt/librarymanagement/CrossVersionTest.scala
@@ -308,14 +308,14 @@ class CrossVersionTest extends UnitSpec {
   it should "for (3.1.1, 3.1.0) return true" in {
     isScalaBinaryCompatibleWith("3.1.1", "3.1.0") shouldBe true
   }
-  it should "for (2.10.0-M1, 2.10.5) return true" in {
-    isScalaBinaryCompatibleWith("2.10.0-M1", "2.10.5") shouldBe true
+  it should "for (2.10.0-M1, 2.10.5) return false" in {
+    isScalaBinaryCompatibleWith("2.10.0-M1", "2.10.5") shouldBe false
   }
-  it should "for (2.10.5, 2.10.0-M1) return true" in {
-    isScalaBinaryCompatibleWith("2.10.5", "2.10.0-M1") shouldBe true
+  it should "for (2.10.5, 2.10.0-M1) return false" in {
+    isScalaBinaryCompatibleWith("2.10.5", "2.10.0-M1") shouldBe false
   }
-  it should "for (2.10.0-M1, 2.10.0-M2) return true" in {
-    isScalaBinaryCompatibleWith("2.10.0-M1", "2.10.0-M2") shouldBe true
+  it should "for (2.10.0-M1, 2.10.0-M2) return false" in {
+    isScalaBinaryCompatibleWith("2.10.0-M1", "2.10.0-M2") shouldBe false
   }
   it should "for (2.10.0-M1, 2.11.0-M1) return false" in {
     isScalaBinaryCompatibleWith("2.10.0-M1", "2.11.0-M1") shouldBe false


### PR DESCRIPTION
Problem
-------
Current impl is relaxed about comparing non-release Scala 2.x versions.

Solutution
----------
Use scalaApiVersion to compare two Scala 2 versions.