### PR TITLE
Try resolve sbt plugins on new Maven path

### DIFF
--- a/ivy/src/main/scala/sbt/internal/librarymanagement/ConvertResolver.scala
+++ b/ivy/src/main/scala/sbt/internal/librarymanagement/ConvertResolver.scala
@@ -27,14 +27,21 @@ import org.apache.ivy.plugins.resolver.{
 import org.apache.ivy.plugins.repository.url.{ URLRepository => URLRepo }
 import org.apache.ivy.plugins.repository.file.{ FileResource, FileRepository => FileRepo }
 import java.io.{ File, IOException }
+import java.util.Date
 
-import org.apache.ivy.util.{ ChecksumHelper, FileUtil, Message }
 import org.apache.ivy.core.module.descriptor.{ Artifact => IArtifact }
+import org.apache.ivy.core.module.id.ModuleRevisionId
 import org.apache.ivy.core.report.DownloadReport
+import org.apache.ivy.plugins.resolver.util.{ ResolvedResource, ResourceMDParser }
+import org.apache.ivy.util.{ ChecksumHelper, FileUtil, Message }
 import sbt.io.IO
 import sbt.util.Logger
 import sbt.librarymanagement._
 import sbt.librarymanagement.ivy.UpdateOptions
+
+import scala.collection.JavaConverters._
+import org.apache.ivy.core.module.descriptor.DefaultArtifact
+import sbt.internal.librarymanagement.mavenint.PomExtraDependencyAttributes
 
 private[sbt] object ConvertResolver {
   import UpdateOptions.ResolverConverter
@@ -173,6 +180,32 @@ private[sbt] object ConvertResolver {
               setArtifactPatterns(pattern)
               setIvyPatterns(pattern)
             }
+            override protected def findResourceUsingPattern(
+                mrid: ModuleRevisionId,
+                pattern: String,
+                artifact: IArtifact,
+                rmdparser: ResourceMDParser,
+                date: Date
+            ): ResolvedResource = {
+              val extraAttributes =
+                mrid.getExtraAttributes.asScala.toMap.asInstanceOf[Map[String, String]]
+              getSbtPluginCrossVersion(extraAttributes) match {
+                case Some(sbtCrossVersion) =>
+                  // if the module is an sbt plugin
+                  // we first try to resolve the artifact with the sbt cross version suffix
+                  // and we fallback to the one without the suffix
+                  val newArtifact = DefaultArtifact.cloneWithAnotherName(
+                    artifact,
+                    artifact.getName + sbtCrossVersion
+                  )
+                  val resolved =
+                    super.findResourceUsingPattern(mrid, pattern, newArtifact, rmdparser, date)
+                  if (resolved != null) resolved
+                  else super.findResourceUsingPattern(mrid, pattern, artifact, rmdparser, date)
+                case None =>
+                  super.findResourceUsingPattern(mrid, pattern, artifact, rmdparser, date)
+              }
+            }
           }
           val resolver = new PluginCapableResolver
           if (repo.localIfFile) resolver.setRepository(new LocalIfFileRepo)
@@ -228,6 +261,13 @@ private[sbt] object ConvertResolver {
             case r: DependencyResolver => r
           }
       }
+  }
+
+  private def getSbtPluginCrossVersion(extraAttributes: Map[String, String]): Option[String] = {
+    for {
+      sbtVersion <- extraAttributes.get(PomExtraDependencyAttributes.SbtVersionKey)
+      scalaVersion <- extraAttributes.get(PomExtraDependencyAttributes.ScalaVersionKey)
+    } yield s"_${scalaVersion}_$sbtVersion"
   }
 
   private sealed trait DescriptorRequired extends BasicResolver {

--- a/ivy/src/test/scala/sbt/internal/librarymanagement/BaseIvySpecification.scala
+++ b/ivy/src/test/scala/sbt/internal/librarymanagement/BaseIvySpecification.scala
@@ -37,7 +37,8 @@ trait BaseIvySpecification extends AbstractEngineSpec {
       deps: Vector[ModuleID],
       scalaFullVersion: Option[String],
       uo: UpdateOptions = UpdateOptions(),
-      overrideScalaVersion: Boolean = true
+      overrideScalaVersion: Boolean = true,
+      appendSbtCrossVersion: Boolean = false
   ): IvySbt#Module = {
     val scalaModuleInfo = scalaFullVersion map { fv =>
       ScalaModuleInfo(
@@ -55,7 +56,7 @@ trait BaseIvySpecification extends AbstractEngineSpec {
       .withConfigurations(configurations)
       .withScalaModuleInfo(scalaModuleInfo)
     val ivySbt = new IvySbt(mkIvyConfiguration(uo))
-    new ivySbt.Module(moduleSetting)
+    new ivySbt.Module(moduleSetting, appendSbtCrossVersion)
   }
 
   def resolvers: Vector[Resolver] = Vector(Resolver.mavenCentral)

--- a/ivy/src/test/scala/sbt/internal/librarymanagement/IvyModuleSpec.scala
+++ b/ivy/src/test/scala/sbt/internal/librarymanagement/IvyModuleSpec.scala
@@ -1,0 +1,38 @@
+package sbt.internal.librarymanagement
+
+import sbt.internal.librarymanagement.mavenint.PomExtraDependencyAttributes.{
+  SbtVersionKey,
+  ScalaVersionKey
+}
+import sbt.librarymanagement.{ CrossVersion, ModuleDescriptorConfiguration }
+
+object IvyModuleSpec extends BaseIvySpecification {
+
+  test("The Scala binary version of a Scala module should be appended to its name") {
+    val m = module(
+      defaultModuleId.withCrossVersion(CrossVersion.Binary()),
+      Vector.empty,
+      Some("2.13.10")
+    )
+    m.moduleSettings match {
+      case configuration: ModuleDescriptorConfiguration =>
+        assert(configuration.module.name == "foo_2.13")
+      case _ => fail()
+    }
+  }
+
+  test("The sbt cross-version should be appended to the name of an sbt plugin") {
+    val m = module(
+      defaultModuleId.extra(SbtVersionKey -> "1.0", ScalaVersionKey -> "2.12"),
+      Vector.empty,
+      Some("2.12.17"),
+      appendSbtCrossVersion = true
+    )
+    m.moduleSettings match {
+      case configuration: ModuleDescriptorConfiguration =>
+        assert(configuration.module.name == "foo_2.12_1.0")
+      case _ => fail()
+    }
+  }
+
+}


### PR DESCRIPTION
sbt plugins were published to an invalid path with regard to Maven's specifictation. For instance, `org/example_2.12_1.0/1.0.0/example-1.0.0.pom` is invalid because the file name `example-1.0.0.pom` does not start with `example_2.12_1.0`, the name of the directory that should correspond to the artifact ID.

As of sbt 1.9, we also publish sbt plugins to the valid path: `example_2.12_1.0/1.0.0/example_2.12_1.0-1.0.0.pom`

For backward compatibility, sbt should try to resolve sbt plugins from the new Maven path, and fallback to the deprecated Maven path.