### PR TITLE
Add Apache Maven Snapshots Repository

### DIFF
--- a/core/src/main/scala/sbt/librarymanagement/ResolverExtra.scala
+++ b/core/src/main/scala/sbt/librarymanagement/ResolverExtra.scala
@@ -180,6 +180,11 @@ private[librarymanagement] abstract class ResolverFunctions {
     )
   def jcenterRepo = JCenterRepository
 
+  val ApacheMavenSnapshotsRepo = MavenRepository(
+    "apache-snapshots",
+    "https://repository.apache.org/content/repositories/snapshots/"
+  )
+
   /** Add the local and Maven Central repositories to the user repositories.  */
   def combineDefaultResolvers(userResolvers: Vector[Resolver]): Vector[Resolver] =
     combineDefaultResolvers(userResolvers, mavenCentral = true)


### PR DESCRIPTION
This PR adds the Apache Maven Snapshots repository (see https://infra.apache.org/repository-faq.html#basic for more details). Note that the releases snapshot repo does not need to be added since its already synced to Maven central, but this should be helpful for sbt users that want to use Apache software snapshots.

Afaik, the `name` field for Maven Repository seems to be purely illustrative, so I just used `apache-snapshots` which seems to follow sbt convention (can also do apache-maven-snapshots if necessary).