### PR TITLE
Alias withLatestSnapshots to withCachedSnapshots

### DIFF
--- a/ivy/src/main/scala/sbt/internal/librarymanagement/Ivy.scala
+++ b/ivy/src/main/scala/sbt/internal/librarymanagement/Ivy.scala
@@ -541,7 +541,7 @@ private[sbt] object IvySbt {
       val delegate = ivyint.SbtChainResolver(delegatedName, rest, settings, updateOptions, log)
       val initialResolvers = projectResolvers :+ delegate
       val freshOptions = UpdateOptions()
-        .withLatestSnapshots(false)
+        .withCachedSnapshots(true)
         .withModuleResolvers(updateOptions.moduleResolvers)
       ivyint.SbtChainResolver(name, initialResolvers, settings, freshOptions, log)
     }

--- a/ivy/src/main/scala/sbt/internal/librarymanagement/ivyint/SbtChainResolver.scala
+++ b/ivy/src/main/scala/sbt/internal/librarymanagement/ivyint/SbtChainResolver.scala
@@ -227,7 +227,7 @@ private[sbt] case class SbtChainResolver(
         if (resolvedModule.getId.getRevision.contains("SNAPSHOT")) {
 
           Message.warn(
-            "Resolving a snapshot version. It's going to be slow unless you use `updateOptions := updateOptions.value.withLatestSnapshots(false)` options."
+            "Resolving a snapshot version. It's going to be slow unless you use `updateOptions := updateOptions.value.withCachedSnapshots(true)` options."
           )
           val resolvers = sortedRevisions.map(_._2.getName)
           sortedRevisions.foreach(h => {
@@ -328,7 +328,7 @@ private[sbt] case class SbtChainResolver(
      */
     def getDependency(dd: DependencyDescriptor, data0: ResolveData): ResolvedModuleRevision = {
       val isDynamic = dd.isChanging || IvySbt.isChanging(dd.getDependencyRevisionId)
-      val useLatest = isDynamic && updateOptions.latestSnapshots
+      val useLatest = isDynamic && !updateOptions.cachedSnapshots
       if (useLatest) Message.verbose(s"$getName is changing. Checking all resolvers on the chain.")
 
       /* Get the resolved module descriptor from:

--- a/ivy/src/main/scala/sbt/librarymanagement/ivy/UpdateOptions.scala
+++ b/ivy/src/main/scala/sbt/librarymanagement/ivy/UpdateOptions.scala
@@ -19,7 +19,7 @@ final class UpdateOptions private[sbt] (
     // If set to true, prioritize inter-project resolver
     val interProjectFirst: Boolean,
     // If set to true, check all resolvers for snapshots.
-    val latestSnapshots: Boolean,
+    val cachedSnapshots: Boolean,
     // If set to true, use cached resolution.
     val cachedResolution: Boolean,
     // If set to true, use Gigahorse
@@ -35,8 +35,11 @@ final class UpdateOptions private[sbt] (
     copy(circularDependencyLevel = circularDependencyLevel)
   def withInterProjectFirst(interProjectFirst: Boolean): UpdateOptions =
     copy(interProjectFirst = interProjectFirst)
+  @deprecated("Use withCachedSnapshots instead with opposite boolean values", "1.9.2")
   def withLatestSnapshots(latestSnapshots: Boolean): UpdateOptions =
-    copy(latestSnapshots = latestSnapshots)
+    withCachedSnapshots(!latestSnapshots)
+  def withCachedSnapshots(cachedSnapshots: Boolean): UpdateOptions =
+    copy(cachedSnapshots = cachedSnapshots)
   def withCachedResolution(cachedResolution: Boolean): UpdateOptions =
     copy(cachedResolution = cachedResolution)
 
@@ -53,7 +56,7 @@ final class UpdateOptions private[sbt] (
   private[sbt] def copy(
       circularDependencyLevel: CircularDependencyLevel = this.circularDependencyLevel,
       interProjectFirst: Boolean = this.interProjectFirst,
-      latestSnapshots: Boolean = this.latestSnapshots,
+      cachedSnapshots: Boolean = this.cachedSnapshots,
       cachedResolution: Boolean = this.cachedResolution,
       gigahorse: Boolean = this.gigahorse,
       resolverConverter: UpdateOptions.ResolverConverter = this.resolverConverter,
@@ -62,7 +65,7 @@ final class UpdateOptions private[sbt] (
     new UpdateOptions(
       circularDependencyLevel,
       interProjectFirst,
-      latestSnapshots,
+      cachedSnapshots,
       cachedResolution,
       gigahorse,
       resolverConverter,
@@ -72,7 +75,7 @@ final class UpdateOptions private[sbt] (
   override def toString(): String =
     s"""UpdateOptions(
         |  circularDependencyLevel = $circularDependencyLevel,
-        |  latestSnapshots = $latestSnapshots,
+        |  cachedSnapshots = $cachedSnapshots,
         |  cachedResolution = $cachedResolution
         |)""".stripMargin
 
@@ -80,7 +83,7 @@ final class UpdateOptions private[sbt] (
     case o: UpdateOptions =>
       this.circularDependencyLevel == o.circularDependencyLevel &&
       this.interProjectFirst == o.interProjectFirst &&
-      this.latestSnapshots == o.latestSnapshots &&
+      this.cachedSnapshots == o.cachedSnapshots &&
       this.cachedResolution == o.cachedResolution &&
       this.gigahorse == o.gigahorse &&
       this.resolverConverter == o.resolverConverter &&
@@ -92,13 +95,17 @@ final class UpdateOptions private[sbt] (
     var hash = 1
     hash = hash * 31 + this.circularDependencyLevel.##
     hash = hash * 31 + this.interProjectFirst.##
-    hash = hash * 31 + this.latestSnapshots.##
+    hash = hash * 31 + this.cachedSnapshots.##
     hash = hash * 31 + this.cachedResolution.##
     hash = hash * 31 + this.gigahorse.##
     hash = hash * 31 + this.resolverConverter.##
     hash = hash * 31 + this.moduleResolvers.##
     hash
   }
+
+  @deprecated("Use cachedSnapshots instead with opposite boolean values", "1.9.2")
+  def latestSnapshots: Boolean = !cachedSnapshots
+
 }
 
 object UpdateOptions {
@@ -108,7 +115,7 @@ object UpdateOptions {
     new UpdateOptions(
       circularDependencyLevel = CircularDependencyLevel.Warn,
       interProjectFirst = true,
-      latestSnapshots = true,
+      cachedSnapshots = false,
       cachedResolution = false,
       gigahorse = LMSysProp.useGigahorse,
       resolverConverter = PartialFunction.empty,

--- a/ivy/src/main/scala/sbt/librarymanagement/ivy/formats/UpdateOptionsFormat.scala
+++ b/ivy/src/main/scala/sbt/librarymanagement/ivy/formats/UpdateOptionsFormat.scala
@@ -23,7 +23,9 @@ trait UpdateOptionsFormat { self: BasicJsonProtocol with ModuleIDFormats with Re
         (
           uo.circularDependencyLevel.name,
           uo.interProjectFirst,
-          uo.latestSnapshots,
+          // This is for compatibility with old latestSnapshots which had opposite boolean value.
+          // Safe to remove negation for sbt 2.0.x?
+          !uo.cachedSnapshots,
           uo.cachedResolution,
           uo.gigahorse,
           uo.moduleResolvers
@@ -32,7 +34,9 @@ trait UpdateOptionsFormat { self: BasicJsonProtocol with ModuleIDFormats with Re
         new UpdateOptions(
           levels(xs._1),
           xs._2,
-          xs._3,
+          // This is for compatibility with old latestSnapshots which had opposite boolean value.
+          // Safe to remove negation for sbt 2.0.x?
+          !xs._3,
           xs._4,
           xs._5,
           PartialFunction.empty,

--- a/ivy/src/test/scala/sbt/internal/librarymanagement/UpdateOptionsSpec.scala
+++ b/ivy/src/test/scala/sbt/internal/librarymanagement/UpdateOptionsSpec.scala
@@ -15,10 +15,10 @@ class UpdateOptionsSpec extends BasicTestSuite {
       UpdateOptions()
         .withCircularDependencyLevel(CircularDependencyLevel.Error)
         .withCachedResolution(true)
-        .withLatestSnapshots(false)
+        .withCachedSnapshots(true)
         .toString() == """|UpdateOptions(
         |  circularDependencyLevel = error,
-        |  latestSnapshots = false,
+        |  cachedSnapshots = true,
         |  cachedResolution = true
         |)""".stripMargin
     )


### PR DESCRIPTION
The main reason behind this change is the current naming isn't really clear (even as a native english speaker) and its already caused confusion (see https://github.com/apache/incubator-pekko-connectors/pull/239#discussion_r1305807641 as an example).

The suggested name change at least in my view makes a lot more clear whats going on, i.e. sbt will cache snapshots versions so they don't re-resolve. I am not too fussed about this name specifically, there are others as well i.e.

* `withAlwaysRefreshSnasphots`
* `withAlwaysCheckSnasphots`

If this PR gets merged I will also update the core sbt build/documentation to reflect this