### PR TITLE
Add withAddedResolvers to DependencyResolutionInterface

### DIFF
--- a/core/src/main/scala/sbt/librarymanagement/DependencyResolution.scala
+++ b/core/src/main/scala/sbt/librarymanagement/DependencyResolution.scala
@@ -198,6 +198,18 @@ class DependencyResolution private[sbt] (lmEngine: DependencyResolutionInterface
     }
   }
 
+  /**
+   * Returns a new copy of DependencyResolutionInterface which contains the added resolvers.
+   * Useful for when you have resolvers that are outside the context of an sbt scope/project
+   * (i.e. a standalone setting)
+   *
+   * @param resolvers The resolvers to add
+   * @param log       The logger
+   * @return A copy of DependencyResolutionInterface which contains the added resolvers
+   */
+  def withAddedResolvers(resolvers: Seq[Resolver], log: Logger): DependencyResolutionInterface =
+    lmEngine.withAddedResolvers(resolvers, log)
+
   protected def directDependenciesNames(module: ModuleDescriptor): String =
     (module.directDependencies map { case mID: ModuleID =>
       import mID._

--- a/core/src/main/scala/sbt/librarymanagement/LibraryManagementInterface.scala
+++ b/core/src/main/scala/sbt/librarymanagement/LibraryManagementInterface.scala
@@ -32,6 +32,16 @@ trait DependencyResolutionInterface {
       uwconfig: UnresolvedWarningConfiguration,
       log: Logger
   ): Either[UnresolvedWarning, UpdateReport]
+
+  /**
+   * Returns a new copy of DependencyResolutionInterface which contains the added resolvers.
+   * Useful for when you have resolvers that are outside the context of an sbt scope/project
+   * (i.e. a standalone setting)
+   * @param resolvers The resolvers to add
+   * @param log The logger
+   * @return A copy of DependencyResolutionInterface which contains the added resolvers
+   */
+  def withAddedResolvers(resolvers: Seq[Resolver], log: Logger): DependencyResolutionInterface
 }
 
 /**

--- a/ivy/src/main/scala/sbt/librarymanagement/ivy/IvyDependencyResolution.scala
+++ b/ivy/src/main/scala/sbt/librarymanagement/ivy/IvyDependencyResolution.scala
@@ -21,6 +21,19 @@ class IvyDependencyResolution private[sbt] (val ivySbt: IvySbt)
   ): Either[UnresolvedWarning, UpdateReport] =
     IvyActions.updateEither(toModule(module), configuration, uwconfig, log)
 
+  override def withAddedResolvers(
+      resolvers: Seq[Resolver],
+      log: Logger
+  ): IvyDependencyResolution = {
+    val newConfiguration = ivySbt.configuration match {
+      case configuration: ExternalIvyConfiguration =>
+        configuration.withExtraResolvers(configuration.extraResolvers ++ resolvers)
+      case configuration: InlineIvyConfiguration =>
+        configuration.withResolvers(configuration.resolvers ++ resolvers)
+    }
+    new IvyDependencyResolution(new IvySbt(newConfiguration))
+  }
+
   private[sbt] def toModule(module: ModuleDescriptor): Module =
     module match {
       case m: Module @unchecked => m


### PR DESCRIPTION
The intent of this PR is to give the ability for a `DependencyResolutionInterface` to add resolvers. The context behind this change is that there are situations where you have sbt plugins that resolve dependencies but not in the context of an sbt project/config. Examples of this are

* [MiMa](https://github.com/lightbend/mima)
* [Reproducible-Builds](https://github.com/raboof/sbt-reproducible-builds)

In both these cases we have an sbt plugin that resolves dependencies from a resolver but its not because those dependencies are in the context of an sbt project (i.e. compiling your code). In MiMa's case we are resolving jar's to check for binary compatibility issues and in sbt-reproducible-builds case we are resolving jar's to confirm that a local build matches a deployed build.

The issue here is if you want to add resolvers that are only necessary for these plugins then currently this is not possible without hacky workarounds (in MiMa's case you would have to create a new sbt subproject that has these extra resolvers just for MiMa and for sbt-reproducible-builds we ended up resolving jars manually, i.e. using gigahorse to manually download the jars).

So idea here is to provide a mechanism so that such sbt plugins can add resolvers just for those plugins so you don't need to pollute the global sbt `resolvers` setting scope.

An interesting point is, if this feature is accepted where it should land i.e. in SBT 1.9 or SBT 2.x. Its theoretically possible to have this in SBT 1.9 with the a default implementation for the `def withAddedResolvers(resolvers: Seq[Resolver], log: Logger): DependencyResolutionInterface` method and sbt plugins responsible for knowing whether the method exists (or not). The problem here is that `DependencyResolutionInterface` is open and hence coursier also provides an implementation of it so there may be an argument that such a change should land in SBT 2.x.