### PR TITLE
Add allModuleReports to UpdateReport

### DIFF
--- a/ivy/src/test/scala/sbt/internal/librarymanagement/FakeResolverSpecification.scala
+++ b/ivy/src/test/scala/sbt/internal/librarymanagement/FakeResolverSpecification.scala
@@ -23,6 +23,7 @@ object FakeResolverSpecification extends BaseIvySpecification {
     val allFiles = getAllFiles(report)
 
     assert(report.allModules.length == 1)
+    assert(report.allModuleReports.length == 1)
     assert(report.configurations.length == 3)
     assert(allFiles.toSet.size == 1)
     assert(allFiles(1).getName == "artifact1-0.0.1-SNAPSHOT.jar")
@@ -34,6 +35,7 @@ object FakeResolverSpecification extends BaseIvySpecification {
     val allFiles = getAllFiles(report).toSet
 
     assert(report.allModules.length == 1)
+    assert(report.allModuleReports.length == 1)
     assert(report.configurations.length == 3)
     assert(allFiles.toSet.size == 2)
     assert(allFiles.map(_.getName) == Set("artifact1-1.0.0.jar", "artifact2-1.0.0.txt"))

--- a/ivy/src/test/scala/sbt/internal/librarymanagement/FrozenModeSpec.scala
+++ b/ivy/src/test/scala/sbt/internal/librarymanagement/FrozenModeSpec.scala
@@ -35,6 +35,7 @@ object FrozenModeSpec extends BaseIvySpecification {
     val onlineResolution = update(toResolve, onlineConf)
     assert(onlineResolution.isRight)
     val numberResolved = onlineResolution.right.get.allModules.size
+    val numberReportsResolved = onlineResolution.right.get.allModuleReports.size
 
     cleanIvyCache()
     val singleFrozenResolution = update(toResolve, frozenConf)
@@ -42,6 +43,10 @@ object FrozenModeSpec extends BaseIvySpecification {
     assert(
       singleFrozenResolution.right.get.allModules.size == 1,
       s"The number of explicit modules in frozen mode should 1"
+    )
+    assert(
+      singleFrozenResolution.right.get.allModuleReports.size == 1,
+      s"The number of explicit module reports in frozen mode should 1"
     )
 
     cleanIvyCache()
@@ -52,6 +57,10 @@ object FrozenModeSpec extends BaseIvySpecification {
     assert(
       frozenResolution.right.get.allModules.size == numberResolved,
       s"The number of explicit modules in frozen mode should be equal than $numberResolved"
+    )
+    assert(
+      frozenResolution.right.get.allModuleReports.size == numberReportsResolved,
+      s"The number of explicit module reports in frozen mode should be equal than $numberReportsResolved"
     )
   }
 }

--- a/ivy/src/test/scala/sbt/internal/librarymanagement/InclExclSpec.scala
+++ b/ivy/src/test/scala/sbt/internal/librarymanagement/InclExclSpec.scala
@@ -68,6 +68,10 @@ object InclExclSpec extends BaseIvySpecification {
       !report.allModules.exists(_.name.contains("lift-json")),
       "lift-json has not been excluded."
     )
+    assert(
+      !report.allModuleReports.exists(_.module.name.contains("lift-json")),
+      "lift-json has not been excluded."
+    )
   }
 
   def testScalaLibraryIsMissing(report: UpdateReport): Unit = {
@@ -75,11 +79,19 @@ object InclExclSpec extends BaseIvySpecification {
       !report.allModules.exists(_.name.contains("scala-library")),
       "scala-library has not been excluded."
     )
+    assert(
+      !report.allModuleReports.exists(_.module.name.contains("scala-library")),
+      "scala-library has not been excluded."
+    )
   }
 
   def testScalahostIsMissing(report: UpdateReport): Unit = {
     assert(
       !report.allModules.exists(_.name.contains("scalahost")),
+      "scalahost has not been excluded."
+    )
+    assert(
+      !report.allModuleReports.exists(_.module.name.contains("scalahost")),
       "scalahost has not been excluded."
     )
   }


### PR DESCRIPTION
I came across this when doing an upcoming change in sbt-license-report (specifically I want to remove sbt-license-report manual usage of Ivy and replace it with `DependencyResolution`/`transitiveUpdate` both of which return an `UpdateReport`). 

Hence this method is needed in order to retrieve extra information (such as license, homepage, etc etc) from an `UpdateReport`