### PR TITLE
Add inliner for Scala 2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -54,12 +54,22 @@ def commonSettings: Seq[Setting[_]] = Def.settings(
   resolvers += Resolver.sonatypeRepo("public"),
   scalacOptions := {
     val old = scalacOptions.value
+    val scala2InlineOptions = List(
+      "-opt-inline-from:<sources>",
+      "-opt:l:inline"
+    )
     scalaVersion.value match {
       case sv if sv.startsWith("2.10") =>
         old diff List("-Xfuture", "-Ywarn-unused", "-Ywarn-unused-import")
       case sv if sv.startsWith("2.11") => old ++ List("-Ywarn-unused", "-Ywarn-unused-import")
       case sv if sv.startsWith("2.12") =>
-        old ++ List("-Ywarn-unused", "-Ywarn-unused-import", "-YdisableFlatCpCaching")
+        old ++ List(
+          "-Ywarn-unused",
+          "-Ywarn-unused-import",
+          "-YdisableFlatCpCaching"
+        ) ++ scala2InlineOptions
+      case sv if sv.startsWith("2.13") =>
+        old ++ scala2InlineOptions
       case _ => old
     }
   },


### PR DESCRIPTION
Adds the [scala inliner/optimizer](https://www.lightbend.com/blog/scala-inliner-optimizer) for Scala 2 versions. The inline options that were picked are the ones determined to be safe for libraries (which sbt-library-management is).

The reasons for adding this is because

* The latest Scala 2 inliner/optimizer is considered to be stable after many years of use
* Its "free" performance especially for older versions of JDK (i.e. JDK 8/JDK 11). I suspect that the majority of people still use sbt this way and in some cases are forced to because of how prevalent JDK 8 is (even though its unfortunate)

One thing to note about the inliner is can cause development hitches locally (i.e. with Scala's incremental compiler). The easiest way to get around this would be to put the inliner behind an argument flag so that CI turns on the inliner (both for PR checks and for publishing) but by default inliner is off so that it doesn't mess with local development. The reason I didn't do this is because it appears that publishing is still done manually on someones machine (I can't see a github action for publishing) and hence it would be easy to forget to enable the inliner when publishing a new version of this library.

I guess if the standard "push tag to trigger a CI" publishing is added to this repo I can then update the PR with this suggestion (I would actually make the inliner an `AutoPlugin).