### PR TITLE
Add JDK 17 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ jobs:
           - os: ubuntu-latest
             java: 11
             jobtype: 1
+          - os: ubuntu-latest
+            java: 17
+            jobtype: 1
     runs-on: ${{ matrix.os }}
     env:
       # define Java options for both official sbt and sbt-extras


### PR DESCRIPTION
JDK 17 is the latest stable LTS JDK so we should test against it