### PR TITLE
Avoid repeating versions in Eviction warning message

### DIFF
--- a/core/src/main/scala/sbt/librarymanagement/EvictionError.scala
+++ b/core/src/main/scala/sbt/librarymanagement/EvictionError.scala
@@ -158,9 +158,6 @@ final class EvictionError private[sbt] (
     out += "found version conflict(s) in library dependencies; some are suspected to be binary incompatible:"
     out += ""
     evictions.foreach({ case (a, scheme) =>
-      val revs = a.evicteds map { _.module.revision }
-      val revsStr =
-        if (revs.size <= 1) revs.mkString else "{" + revs.distinct.mkString(", ") + "}"
       val seen: mutable.Set[ModuleID] = mutable.Set()
       val callers: List[String] = (a.evicteds.toList ::: a.winner.toList) flatMap { r =>
         val rev = r.module.revision
@@ -174,7 +171,7 @@ final class EvictionError private[sbt] (
       }
       val que = if (assumed) "?" else ""
       val winnerRev = a.winner match {
-        case Some(r) => s":${r.module.revision} ($scheme$que) is selected over ${revsStr}"
+        case Some(r) => s":${r.module.revision} ($scheme$que) is selected over ${a.evictedRevs}"
         case _       => " is evicted for all versions"
       }
       val title = s"\t* ${a.organization}:${a.name}$winnerRev"

--- a/core/src/main/scala/sbt/librarymanagement/EvictionWarning.scala
+++ b/core/src/main/scala/sbt/librarymanagement/EvictionWarning.scala
@@ -191,6 +191,11 @@ final class EvictionPair private[sbt] (
     val includesDirect: Boolean,
     val showCallers: Boolean
 ) {
+  val evictedRevs: String = {
+    val revs = evicteds map { _.module.revision }
+    if (revs.size <= 1) revs.mkString else revs.distinct.mkString("{", ", ", "}")
+  }
+
   override def toString: String =
     EvictionPair.evictionPairLines.showLines(this).mkString
   override def equals(o: Any): Boolean = o match {
@@ -209,8 +214,6 @@ final class EvictionPair private[sbt] (
 
 object EvictionPair {
   implicit val evictionPairLines: ShowLines[EvictionPair] = ShowLines { (a: EvictionPair) =>
-    val revs = a.evicteds map { _.module.revision }
-    val revsStr = if (revs.size <= 1) revs.mkString else "{" + revs.mkString(", ") + "}"
     val seen: mutable.Set[ModuleID] = mutable.Set()
     val callers: List[String] = (a.evicteds.toList ::: a.winner.toList) flatMap { r =>
       val rev = r.module.revision
@@ -223,7 +226,7 @@ object EvictionPair {
       }
     }
     val winnerRev = a.winner match {
-      case Some(r) => s":${r.module.revision} is selected over ${revsStr}"
+      case Some(r) => s":${r.module.revision} is selected over ${a.evictedRevs}"
       case _       => " is evicted for all versions"
     }
     val title = s"\t* ${a.organization}:${a.name}$winnerRev"


### PR DESCRIPTION
As with PR https://github.com/sbt/librarymanagement/pull/386, which dealt with Eviction **errors**, this fixes the way `EvictionWarning` reports the list of evicted versions - removing duplicate revisions that look like this:

```
* org.scala-lang.modules:scala-java8-compat_2.13:1.0.2 is selected over {1.0.0, 1.0.0}
```

This fix does a refactor so that both `EvictionError` & `EvictionWarning` are using the same logic to generate the revision string - the logic is moved to the new field `EvictionPair.evictedRevs`.

