### PR TITLE
fix warnings. `Resolver.sonatypeRepo` => `Resolver.sonatypeOssRepos`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,14 +44,14 @@ def commonSettings: Seq[Setting[_]] = Def.settings(
   scalaVersion := scala212,
   // publishArtifact in packageDoc := false,
   resolvers += Resolver.typesafeIvyRepo("releases"),
-  resolvers += Resolver.sonatypeRepo("snapshots"),
+  resolvers ++= Resolver.sonatypeOssRepos("snapshots"),
   resolvers += Resolver.sbtPluginRepo("releases"),
   testFrameworks += new TestFramework("verify.runner.Framework"),
   // concurrentRestrictions in Global += Util.testExclusiveRestriction,
   testOptions += Tests.Argument(TestFrameworks.ScalaCheck, "-w", "1"),
   compile / javacOptions ++= Seq("-Xlint", "-Xlint:-serial"),
   crossScalaVersions := Seq(scala212, scala213),
-  resolvers += Resolver.sonatypeRepo("public"),
+  resolvers ++= Resolver.sonatypeOssRepos("public"),
   scalacOptions := {
     val old = scalacOptions.value
     scalaVersion.value match {


### PR DESCRIPTION
https://github.com/sbt/librarymanagement/blob/aa090bdb251f83810ee17ba7ef0f813bd4754fc0/core/src/main/scala/sbt/librarymanagement/ResolverExtra.scala#L159-L163

```
/home/runner/work/librarymanagement/librarymanagement/build.sbt:47: warning: method sonatypeRepo in class ResolverFunctions is deprecated (since 1.7.0): Use sonatypeOssRepos instead e.g. `resolvers ++= Resolver.sonatypeOssRepos("snapshots")`
  resolvers += Resolver.sonatypeRepo("snapshots"),
                        ^
/home/runner/work/librarymanagement/librarymanagement/build.sbt:54: warning: method sonatypeRepo in class ResolverFunctions is deprecated (since 1.7.0): Use sonatypeOssRepos instead e.g. `resolvers ++= Resolver.sonatypeOssRepos("snapshots")`
  resolvers += Resolver.sonatypeRepo("public"),
                        ^
```