### PR TITLE
set overrideScalaVersion to false by default

### DIFF
--- a/ivy/src/test/scala/sbt/internal/librarymanagement/BaseIvySpecification.scala
+++ b/ivy/src/test/scala/sbt/internal/librarymanagement/BaseIvySpecification.scala
@@ -37,7 +37,7 @@ trait BaseIvySpecification extends AbstractEngineSpec {
       deps: Vector[ModuleID],
       scalaFullVersion: Option[String],
       uo: UpdateOptions = UpdateOptions(),
-      overrideScalaVersion: Boolean = true,
+      overrideScalaVersion: Boolean = false,
       appendSbtCrossVersion: Boolean = false
   ): IvySbt#Module = {
     val scalaModuleInfo = scalaFullVersion map { fv =>

--- a/ivy/src/test/scala/sbt/internal/librarymanagement/EvictionErrorSpec.scala
+++ b/ivy/src/test/scala/sbt/internal/librarymanagement/EvictionErrorSpec.scala
@@ -164,6 +164,6 @@ object EvictionErrorSpec extends BaseIvySpecification {
       configurations = Vector.empty,
       checkExplicit = true,
       filterImplicit = false,
-      overrideScalaVersion = true
+      overrideScalaVersion = false
     )
 }

--- a/ivy/src/test/scala/sbt/internal/librarymanagement/EvictionWarningSpec.scala
+++ b/ivy/src/test/scala/sbt/internal/librarymanagement/EvictionWarningSpec.scala
@@ -358,6 +358,6 @@ object EvictionWarningSpec extends BaseIvySpecification {
       configurations = Vector.empty,
       checkExplicit = true,
       filterImplicit = false,
-      overrideScalaVersion = true
+      overrideScalaVersion = false
     )
 }


### PR DESCRIPTION
One of the pieces needed for [SIP-51](https://docs.scala-lang.org/sips/drop-stdlib-forwards-bin-compat.html)