### PR TITLE
Preserve backslashes in `expandMavenSettings`

### DIFF
--- a/core/src/test/scala/sbt/librarymanagement/ResolverExtraTest.scala
+++ b/core/src/test/scala/sbt/librarymanagement/ResolverExtraTest.scala
@@ -33,6 +33,13 @@ object ResolverExtraTest extends BasicTestSuite {
     )
   }
 
+  test("expandMavenSettings should preserve backslashes in environment variable values") {
+    val path = """C:\foo\bar\baz"""
+    val env = Map("SOME_PATH" -> path)
+
+    assert(Resolver.expandMavenSettings("${env.SOME_PATH}", env) == path)
+  }
+
   // - Helper functions ----------------------------------------------------------------------------
   // -----------------------------------------------------------------------------------------------
   def assertExpansion(input: String, expected: String) =


### PR DESCRIPTION
We use `expandMavenSettings` to turn environment variable expressions in `settings.xml` into their actual values.

Before this change, if an environment variable value contained backslashes, they would have been treated as escape characters by `Regex.replaceAllIn` and removed from the returned string. This caused an issue when using backslashes for Windows paths.