### PR TITLE
[1.10.x] Exclude custom extra from pom dependency

### DIFF
--- a/ivy/src/test/scala/sbt/internal/librarymanagement/ModuleResolversTest.scala
+++ b/ivy/src/test/scala/sbt/internal/librarymanagement/ModuleResolversTest.scala
@@ -3,13 +3,13 @@ package sbt.internal.librarymanagement
 import sbt.librarymanagement._
 import sbt.librarymanagement.syntax._
 import sbt.librarymanagement.ivy.UpdateOptions
-import Resolver._
 
 object ModuleResolversTest extends BaseIvySpecification {
   override final val resolvers = Vector(
-    DefaultMavenRepository,
-    JavaNet2Repository,
-    JCenterRepository,
+    MavenRepository(
+      "JFrog OSS Releases",
+      "https://releases.jfrog.io/artifactory/oss-releases/"
+    ),
     Resolver.sbtPluginRepo("releases")
   )
 


### PR DESCRIPTION
Fix https://github.com/sbt/sbt/issues/7710

Custom extra attributes are not used for resolution. We remove them from POM `extraDependencyAttributes`, so they don't mess up the conflict resolution in Coursier (or Maven).

For instance [this POM file](https://repo1.maven.org/maven2/com/armanbilge/sbt-scala-native-config-brew-github-actions_2.12_1.0/0.3.0/sbt-scala-native-config-brew-github-actions_2.12_1.0-0.3.0.pom) contains too many dependency extra attributes: `e:info.apiURL`, `e:info.versionScheme` and `e:info.releaseNotesUrl` should be ignored

```
<extraDependencyAttributes xml:space="preserve">
+e:info.apiURL:#@#:+https://www.javadoc.io/doc/com.armanbilge/sbt-scala-native-config-brew_2.12/0.3.0/:#@#:
+e:sbtVersion:#@#:+1.0:#@#:
+e:info.releaseNotesUrl:#@#:
+https://github.com/armanbilge/scala-native-config-brew/releases/tag/v0.3.0:#@#:
+module:#@#:+sbt-scala-native-config-brew_2.12_1.0:#@#:
+e:scalaVersion:#@#:+2.12:#@#:$
+e:info.versionScheme:#@#:+early-semver:#@#:
+organisation:#@#:+com.armanbilge:#@#:
+branch:#@#:+@#:NULL:#@:#@#:
+revision:#@#:+0.3.0:#@#:
+e:sbtVersion:#@#:+1.0:#@#:
+module:#@#:+sbt-typelevel-github-actions_2.12_1.0:#@#:
+e:scalaVersion:#@#:+2.12:#@#:
+organisation:#@#:+org.typelevel:#@#:
+branch:#@#:+@#:NULL:#@:#@#:
+revision:#@#:+0.7.0:#@#:
</extraDependencyAttributes>
```
