### PR TITLE
[2.x] fix more warnings

### DIFF
--- a/core/src/main/contraband-scala/sbt/internal/librarymanagement/SemComparator.scala
+++ b/core/src/main/contraband-scala/sbt/internal/librarymanagement/SemComparator.scala
@@ -13,42 +13,42 @@ final class SemComparator private (
   def matches(version: sbt.librarymanagement.VersionNumber): Boolean = this.matchesImpl(version)
   def expandWildcard: Seq[SemComparator] = {
     if (op == sbt.internal.librarymanagement.SemSelOperator.Eq && !allFieldsSpecified) {
-    Seq(
-    this.withOp(sbt.internal.librarymanagement.SemSelOperator.Gte),
-    this.withOp(sbt.internal.librarymanagement.SemSelOperator.Lte)
-    )
-  } else { Seq(this) }
-}
+      Seq(
+        this.withOp(sbt.internal.librarymanagement.SemSelOperator.Gte),
+        this.withOp(sbt.internal.librarymanagement.SemSelOperator.Lte)
+      )
+    } else { Seq(this) }
+  }
 
 
-override def equals(o: Any): Boolean = this.eq(o.asInstanceOf[AnyRef]) || (o match {
-  case x: SemComparator => (this.op == x.op) && (this.major == x.major) && (this.minor == x.minor) && (this.patch == x.patch) && (this.tags == x.tags)
-  case _ => false
-})
-override def hashCode: Int = {
-  37 * (37 * (37 * (37 * (37 * (37 * (17 + "sbt.internal.librarymanagement.SemComparator".##) + op.##) + major.##) + minor.##) + patch.##) + tags.##)
-}
-override def toString: String = {
-  this.toStringImpl
-}
-private[this] def copy(op: sbt.internal.librarymanagement.SemSelOperator = op, major: Option[Long] = major, minor: Option[Long] = minor, patch: Option[Long] = patch, tags: Seq[String] = tags): SemComparator = {
-  new SemComparator(op, major, minor, patch, tags)
-}
-def withOp(op: sbt.internal.librarymanagement.SemSelOperator): SemComparator = {
-  copy(op = op)
-}
-def withMajor(major: Option[Long]): SemComparator = {
-  copy(major = major)
-}
-def withMinor(minor: Option[Long]): SemComparator = {
-  copy(minor = minor)
-}
-def withPatch(patch: Option[Long]): SemComparator = {
-  copy(patch = patch)
-}
-def withTags(tags: Seq[String]): SemComparator = {
-  copy(tags = tags)
-}
+  override def equals(o: Any): Boolean = this.eq(o.asInstanceOf[AnyRef]) || (o match {
+    case x: SemComparator => (this.op == x.op) && (this.major == x.major) && (this.minor == x.minor) && (this.patch == x.patch) && (this.tags == x.tags)
+    case _ => false
+  })
+  override def hashCode: Int = {
+    37 * (37 * (37 * (37 * (37 * (37 * (17 + "sbt.internal.librarymanagement.SemComparator".##) + op.##) + major.##) + minor.##) + patch.##) + tags.##)
+  }
+  override def toString: String = {
+    this.toStringImpl
+  }
+  private[this] def copy(op: sbt.internal.librarymanagement.SemSelOperator = op, major: Option[Long] = major, minor: Option[Long] = minor, patch: Option[Long] = patch, tags: Seq[String] = tags): SemComparator = {
+    new SemComparator(op, major, minor, patch, tags)
+  }
+  def withOp(op: sbt.internal.librarymanagement.SemSelOperator): SemComparator = {
+    copy(op = op)
+  }
+  def withMajor(major: Option[Long]): SemComparator = {
+    copy(major = major)
+  }
+  def withMinor(minor: Option[Long]): SemComparator = {
+    copy(minor = minor)
+  }
+  def withPatch(patch: Option[Long]): SemComparator = {
+    copy(patch = patch)
+  }
+  def withTags(tags: Seq[String]): SemComparator = {
+    copy(tags = tags)
+  }
 }
 object SemComparator extends sbt.internal.librarymanagement.SemComparatorFunctions {
   def apply(comparator: String): SemComparator = parse(comparator)

--- a/core/src/main/contraband-scala/sbt/librarymanagement/SemanticSelector.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/SemanticSelector.scala
@@ -84,7 +84,7 @@ object SemanticSelector {
   def apply(selector: String): SemanticSelector = {
     val orChunkTokens = selector.split("\\s+\\|\\|\\s+").map(_.trim)
     val orChunks = orChunkTokens.map { chunk => sbt.internal.librarymanagement.SemSelAndChunk(chunk) }
-    SemanticSelector(orChunks)
+    SemanticSelector(scala.collection.immutable.ArraySeq.unsafeWrapArray(orChunks))
   }
   def apply(selectors: Seq[sbt.internal.librarymanagement.SemSelAndChunk]): SemanticSelector = new SemanticSelector(selectors)
 }

--- a/core/src/main/contraband/librarymanagement2.json
+++ b/core/src/main/contraband/librarymanagement2.json
@@ -87,7 +87,7 @@
         "def apply(selector: String): SemanticSelector = {",
         "  val orChunkTokens = selector.split(\"\\\\s+\\\\|\\\\|\\\\s+\").map(_.trim)",
         "  val orChunks = orChunkTokens.map { chunk => sbt.internal.librarymanagement.SemSelAndChunk(chunk) }",
-        "  SemanticSelector(orChunks)",
+        "  SemanticSelector(scala.collection.immutable.ArraySeq.unsafeWrapArray(orChunks))",
         "}"
       ]
     },

--- a/core/src/main/scala/sbt/internal/librarymanagement/SemanticSelectorExtra.scala
+++ b/core/src/main/scala/sbt/internal/librarymanagement/SemanticSelectorExtra.scala
@@ -8,7 +8,8 @@ import java.util.Locale
 
 private[librarymanagement] abstract class SemSelAndChunkFunctions {
   protected def parse(andClauseToken: String): SemSelAndChunk = {
-    val comparatorTokens = andClauseToken.split("\\s+")
+    val comparatorTokens =
+      scala.collection.immutable.ArraySeq.unsafeWrapArray(andClauseToken.split("\\s+"))
     val hyphenIndex = comparatorTokens.indexWhere(_ == "-")
     val comparators = if (hyphenIndex == -1) {
       comparatorTokens.map(SemComparator.apply)

--- a/core/src/main/scala/sbt/internal/librarymanagement/formats/GlobalLockFormat.scala
+++ b/core/src/main/scala/sbt/internal/librarymanagement/formats/GlobalLockFormat.scala
@@ -15,7 +15,7 @@ trait GlobalLockFormat { self: BasicJsonProtocol =>
   implicit lazy val globalLockIsoString: IsoString[GlobalLock] =
     IsoString.iso(_ => "<lock>", _ => NoGlobalLock)
 
-  implicit lazy val GlobalLockFormat: JsonFormat[GlobalLock] = implicitly
+  implicit lazy val GlobalLockFormat: JsonFormat[GlobalLock] = isoStringFormat(globalLockIsoString)
 }
 
 private[sbt] object GlobalLockFormats {

--- a/core/src/main/scala/sbt/internal/librarymanagement/formats/LoggerFormat.scala
+++ b/core/src/main/scala/sbt/internal/librarymanagement/formats/LoggerFormat.scala
@@ -12,5 +12,5 @@ trait LoggerFormat { self: BasicJsonProtocol =>
   implicit lazy val xsbtiLoggerIsoString: IsoString[Logger] =
     IsoString.iso(_ => "<logger>", _ => Null)
 
-  implicit lazy val LoggerFormat: JsonFormat[Logger] = implicitly
+  implicit lazy val LoggerFormat: JsonFormat[Logger] = isoStringFormat(implicitly)
 }

--- a/ivy/src/main/contraband-scala/sbt/librarymanagement/ivy/ExternalIvyConfigurationFormats.scala
+++ b/ivy/src/main/contraband-scala/sbt/librarymanagement/ivy/ExternalIvyConfigurationFormats.scala
@@ -36,32 +36,32 @@ trait ExternalIvyConfigurationFormats { self: sbt.internal.librarymanagement.for
     with sbt.librarymanagement.SftpRepositoryFormats
     with sbt.librarymanagement.PasswordAuthenticationFormats
     with sbt.librarymanagement.KeyFileAuthenticationFormats =>
-implicit lazy val ExternalIvyConfigurationFormat: JsonFormat[sbt.librarymanagement.ivy.ExternalIvyConfiguration] = new JsonFormat[sbt.librarymanagement.ivy.ExternalIvyConfiguration] {
-  override def read[J](__jsOpt: Option[J], unbuilder: Unbuilder[J]): sbt.librarymanagement.ivy.ExternalIvyConfiguration = {
-    __jsOpt match {
-      case Some(__js) =>
-      unbuilder.beginObject(__js)
-      val lock = unbuilder.readField[Option[xsbti.GlobalLock]]("lock")
-      val log = unbuilder.readField[Option[xsbti.Logger]]("log")
-      val updateOptions = unbuilder.readField[sbt.librarymanagement.ivy.UpdateOptions]("updateOptions")
-      val baseDirectory = unbuilder.readField[Option[java.io.File]]("baseDirectory")
-      val uri = unbuilder.readField[Option[java.net.URI]]("uri")
-      val extraResolvers = unbuilder.readField[Vector[sbt.librarymanagement.Resolver]]("extraResolvers")
-      unbuilder.endObject()
-      sbt.librarymanagement.ivy.ExternalIvyConfiguration(lock, log, updateOptions, baseDirectory, uri, extraResolvers)
-      case None =>
-      deserializationError("Expected JsObject but found None")
+    implicit lazy val ExternalIvyConfigurationFormat: JsonFormat[sbt.librarymanagement.ivy.ExternalIvyConfiguration] = new JsonFormat[sbt.librarymanagement.ivy.ExternalIvyConfiguration] {
+      override def read[J](__jsOpt: Option[J], unbuilder: Unbuilder[J]): sbt.librarymanagement.ivy.ExternalIvyConfiguration = {
+        __jsOpt match {
+          case Some(__js) =>
+          unbuilder.beginObject(__js)
+          val lock = unbuilder.readField[Option[xsbti.GlobalLock]]("lock")
+          val log = unbuilder.readField[Option[xsbti.Logger]]("log")
+          val updateOptions = unbuilder.readField[sbt.librarymanagement.ivy.UpdateOptions]("updateOptions")
+          val baseDirectory = unbuilder.readField[Option[java.io.File]]("baseDirectory")
+          val uri = unbuilder.readField[Option[java.net.URI]]("uri")
+          val extraResolvers = unbuilder.readField[Vector[sbt.librarymanagement.Resolver]]("extraResolvers")
+          unbuilder.endObject()
+          sbt.librarymanagement.ivy.ExternalIvyConfiguration(lock, log, updateOptions, baseDirectory, uri, extraResolvers)
+          case None =>
+          deserializationError("Expected JsObject but found None")
+        }
+      }
+      override def write[J](obj: sbt.librarymanagement.ivy.ExternalIvyConfiguration, builder: Builder[J]): Unit = {
+        builder.beginObject()
+        builder.addField("lock", obj.lock)
+        builder.addField("log", obj.log)
+        builder.addField("updateOptions", obj.updateOptions)
+        builder.addField("baseDirectory", obj.baseDirectory)
+        builder.addField("uri", obj.uri)
+        builder.addField("extraResolvers", obj.extraResolvers)
+        builder.endObject()
+      }
     }
-  }
-  override def write[J](obj: sbt.librarymanagement.ivy.ExternalIvyConfiguration, builder: Builder[J]): Unit = {
-    builder.beginObject()
-    builder.addField("lock", obj.lock)
-    builder.addField("log", obj.log)
-    builder.addField("updateOptions", obj.updateOptions)
-    builder.addField("baseDirectory", obj.baseDirectory)
-    builder.addField("uri", obj.uri)
-    builder.addField("extraResolvers", obj.extraResolvers)
-    builder.endObject()
-  }
-}
 }

--- a/ivy/src/main/contraband-scala/sbt/librarymanagement/ivy/InlineIvyConfigurationFormats.scala
+++ b/ivy/src/main/contraband-scala/sbt/librarymanagement/ivy/InlineIvyConfigurationFormats.scala
@@ -38,40 +38,40 @@ trait InlineIvyConfigurationFormats { self: sbt.internal.librarymanagement.forma
     with sbt.librarymanagement.SftpRepositoryFormats
     with sbt.librarymanagement.PasswordAuthenticationFormats
     with sbt.librarymanagement.KeyFileAuthenticationFormats =>
-implicit lazy val InlineIvyConfigurationFormat: JsonFormat[sbt.librarymanagement.ivy.InlineIvyConfiguration] = new JsonFormat[sbt.librarymanagement.ivy.InlineIvyConfiguration] {
-  override def read[J](__jsOpt: Option[J], unbuilder: Unbuilder[J]): sbt.librarymanagement.ivy.InlineIvyConfiguration = {
-    __jsOpt match {
-      case Some(__js) =>
-      unbuilder.beginObject(__js)
-      val lock = unbuilder.readField[Option[xsbti.GlobalLock]]("lock")
-      val log = unbuilder.readField[Option[xsbti.Logger]]("log")
-      val updateOptions = unbuilder.readField[sbt.librarymanagement.ivy.UpdateOptions]("updateOptions")
-      val paths = unbuilder.readField[Option[sbt.librarymanagement.ivy.IvyPaths]]("paths")
-      val resolvers = unbuilder.readField[Vector[sbt.librarymanagement.Resolver]]("resolvers")
-      val otherResolvers = unbuilder.readField[Vector[sbt.librarymanagement.Resolver]]("otherResolvers")
-      val moduleConfigurations = unbuilder.readField[Vector[sbt.librarymanagement.ModuleConfiguration]]("moduleConfigurations")
-      val checksums = unbuilder.readField[Vector[String]]("checksums")
-      val managedChecksums = unbuilder.readField[Boolean]("managedChecksums")
-      val resolutionCacheDir = unbuilder.readField[Option[java.io.File]]("resolutionCacheDir")
-      unbuilder.endObject()
-      sbt.librarymanagement.ivy.InlineIvyConfiguration(lock, log, updateOptions, paths, resolvers, otherResolvers, moduleConfigurations, checksums, managedChecksums, resolutionCacheDir)
-      case None =>
-      deserializationError("Expected JsObject but found None")
+    implicit lazy val InlineIvyConfigurationFormat: JsonFormat[sbt.librarymanagement.ivy.InlineIvyConfiguration] = new JsonFormat[sbt.librarymanagement.ivy.InlineIvyConfiguration] {
+      override def read[J](__jsOpt: Option[J], unbuilder: Unbuilder[J]): sbt.librarymanagement.ivy.InlineIvyConfiguration = {
+        __jsOpt match {
+          case Some(__js) =>
+          unbuilder.beginObject(__js)
+          val lock = unbuilder.readField[Option[xsbti.GlobalLock]]("lock")
+          val log = unbuilder.readField[Option[xsbti.Logger]]("log")
+          val updateOptions = unbuilder.readField[sbt.librarymanagement.ivy.UpdateOptions]("updateOptions")
+          val paths = unbuilder.readField[Option[sbt.librarymanagement.ivy.IvyPaths]]("paths")
+          val resolvers = unbuilder.readField[Vector[sbt.librarymanagement.Resolver]]("resolvers")
+          val otherResolvers = unbuilder.readField[Vector[sbt.librarymanagement.Resolver]]("otherResolvers")
+          val moduleConfigurations = unbuilder.readField[Vector[sbt.librarymanagement.ModuleConfiguration]]("moduleConfigurations")
+          val checksums = unbuilder.readField[Vector[String]]("checksums")
+          val managedChecksums = unbuilder.readField[Boolean]("managedChecksums")
+          val resolutionCacheDir = unbuilder.readField[Option[java.io.File]]("resolutionCacheDir")
+          unbuilder.endObject()
+          sbt.librarymanagement.ivy.InlineIvyConfiguration(lock, log, updateOptions, paths, resolvers, otherResolvers, moduleConfigurations, checksums, managedChecksums, resolutionCacheDir)
+          case None =>
+          deserializationError("Expected JsObject but found None")
+        }
+      }
+      override def write[J](obj: sbt.librarymanagement.ivy.InlineIvyConfiguration, builder: Builder[J]): Unit = {
+        builder.beginObject()
+        builder.addField("lock", obj.lock)
+        builder.addField("log", obj.log)
+        builder.addField("updateOptions", obj.updateOptions)
+        builder.addField("paths", obj.paths)
+        builder.addField("resolvers", obj.resolvers)
+        builder.addField("otherResolvers", obj.otherResolvers)
+        builder.addField("moduleConfigurations", obj.moduleConfigurations)
+        builder.addField("checksums", obj.checksums)
+        builder.addField("managedChecksums", obj.managedChecksums)
+        builder.addField("resolutionCacheDir", obj.resolutionCacheDir)
+        builder.endObject()
+      }
     }
-  }
-  override def write[J](obj: sbt.librarymanagement.ivy.InlineIvyConfiguration, builder: Builder[J]): Unit = {
-    builder.beginObject()
-    builder.addField("lock", obj.lock)
-    builder.addField("log", obj.log)
-    builder.addField("updateOptions", obj.updateOptions)
-    builder.addField("paths", obj.paths)
-    builder.addField("resolvers", obj.resolvers)
-    builder.addField("otherResolvers", obj.otherResolvers)
-    builder.addField("moduleConfigurations", obj.moduleConfigurations)
-    builder.addField("checksums", obj.checksums)
-    builder.addField("managedChecksums", obj.managedChecksums)
-    builder.addField("resolutionCacheDir", obj.resolutionCacheDir)
-    builder.endObject()
-  }
-}
 }

--- a/ivy/src/main/contraband-scala/sbt/librarymanagement/ivy/IvyConfigurationFormats.scala
+++ b/ivy/src/main/contraband-scala/sbt/librarymanagement/ivy/IvyConfigurationFormats.scala
@@ -41,5 +41,5 @@ trait IvyConfigurationFormats { self: sbt.internal.librarymanagement.formats.Glo
     with sbt.librarymanagement.SftpRepositoryFormats
     with sbt.librarymanagement.PasswordAuthenticationFormats
     with sbt.librarymanagement.KeyFileAuthenticationFormats =>
-implicit lazy val IvyConfigurationFormat: JsonFormat[sbt.librarymanagement.ivy.IvyConfiguration] = flatUnionFormat2[sbt.librarymanagement.ivy.IvyConfiguration, sbt.librarymanagement.ivy.InlineIvyConfiguration, sbt.librarymanagement.ivy.ExternalIvyConfiguration]("type")
+    implicit lazy val IvyConfigurationFormat: JsonFormat[sbt.librarymanagement.ivy.IvyConfiguration] = flatUnionFormat2[sbt.librarymanagement.ivy.IvyConfiguration, sbt.librarymanagement.ivy.InlineIvyConfiguration, sbt.librarymanagement.ivy.ExternalIvyConfiguration]("type")
 }

--- a/ivy/src/main/scala/sbt/internal/librarymanagement/ConvertResolver.scala
+++ b/ivy/src/main/scala/sbt/internal/librarymanagement/ConvertResolver.scala
@@ -50,16 +50,11 @@ private[sbt] object ConvertResolver {
    * checksum-friendly URL publishing shim.
    */
   private object ChecksumFriendlyURLResolver {
-    // TODO - When we dump JDK6 support we can remove this hackery
-    // import java.lang.reflect.AccessibleObject
-    type AccessibleObject = {
-      def setAccessible(value: Boolean): Unit
-    }
+    import java.lang.reflect.AccessibleObject
     private def reflectiveLookup[A <: AccessibleObject](f: Class[_] => A): Option[A] =
       try {
         val cls = classOf[RepositoryResolver]
         val thing = f(cls)
-        import scala.language.reflectiveCalls
         thing.setAccessible(true)
         Some(thing)
       } catch {

--- a/ivy/src/main/scala/sbt/internal/librarymanagement/CustomPomParser.scala
+++ b/ivy/src/main/scala/sbt/internal/librarymanagement/CustomPomParser.scala
@@ -29,6 +29,7 @@ import sbt.internal.librarymanagement.mavenint.{
   SbtPomExtraProperties
 }
 import sbt.io.Hash
+import scala.collection.immutable.ArraySeq
 
 // @deprecated("We now use an Aether-based pom parser.", "0.13.8")
 final class CustomPomParser(
@@ -311,7 +312,7 @@ object CustomPomParser {
     ) dmd.addExtraAttributeNamespace(key, value)
     IvySbt.addExtraNamespace(dmd)
 
-    val withExtra = md.getDependencies map { dd =>
+    val withExtra = ArraySeq.unsafeWrapArray(md.getDependencies) map { dd =>
       addExtra(dd, dependencyExtra)
     }
     val withVersionRangeMod: Seq[DependencyDescriptor] =

--- a/ivy/src/main/scala/sbt/internal/librarymanagement/Ivy.scala
+++ b/ivy/src/main/scala/sbt/internal/librarymanagement/Ivy.scala
@@ -36,6 +36,7 @@ import org.apache.ivy.util.extendable.ExtendableItem
 import org.apache.ivy.util.url._
 import scala.xml.NodeSeq
 import scala.collection.mutable
+import scala.collection.immutable.ArraySeq
 import scala.util.{ Success, Failure }
 import sbt.util._
 import sbt.librarymanagement.{ ModuleDescriptorConfiguration => InlineConfiguration, _ }
@@ -891,7 +892,7 @@ private[sbt] object IvySbt {
 
   def inconsistentDuplicateWarning(moduleID: DefaultModuleDescriptor): List[String] = {
     import IvyRetrieve.toModuleID
-    val dds = moduleID.getDependencies
+    val dds = ArraySeq.unsafeWrapArray(moduleID.getDependencies)
     val deps = dds flatMap { dd =>
       val module = toModuleID(dd.getDependencyRevisionId)
       dd.getModuleConfigurations map (c => module.withConfigurations(Some(c)))

--- a/ivy/src/main/scala/sbt/internal/librarymanagement/IvyActions.scala
+++ b/ivy/src/main/scala/sbt/internal/librarymanagement/IvyActions.scala
@@ -320,8 +320,9 @@ object IvyActions {
 
     val resolveReport = ivyInstance.resolve(moduleDescriptor, resolveOptions)
     if (resolveReport.hasError && !missingOk) {
+      import scala.jdk.CollectionConverters._
       // If strict error, collect report information and generated UnresolvedWarning
-      val messages = resolveReport.getAllProblemMessages.toArray.map(_.toString).distinct
+      val messages = resolveReport.getAllProblemMessages.asScala.toSeq.map(_.toString).distinct
       val failedPaths = resolveReport.getUnresolvedDependencies.map { node =>
         val moduleID = IvyRetrieve.toModuleID(node.getId)
         val path = IvyRetrieve

--- a/ivy/src/main/scala/sbt/internal/librarymanagement/IvyRetrieve.scala
+++ b/ivy/src/main/scala/sbt/internal/librarymanagement/IvyRetrieve.scala
@@ -6,6 +6,7 @@ package sbt.internal.librarymanagement
 import java.io.File
 import java.{ util => ju }
 import collection.mutable
+import collection.immutable.ArraySeq
 import org.apache.ivy.core.{ module, report, resolve }
 import module.descriptor.{ Artifact => IvyArtifact, License => IvyLicense }
 import module.id.{ ModuleRevisionId, ModuleId => IvyModuleId }
@@ -187,7 +188,9 @@ object IvyRetrieve {
       case _ => Vector.empty
     }
     val callers = dep.getCallers(confReport.getConfiguration).toVector map { toCaller }
-    val (resolved, missing) = artifacts(confReport getDownloadReports revId)
+    val (resolved, missing) = artifacts(
+      ArraySeq.unsafeWrapArray(confReport.getDownloadReports(revId))
+    )
 
     ModuleReport(
       moduleId,
@@ -212,7 +215,7 @@ object IvyRetrieve {
   }
 
   def evicted(confReport: ConfigurationResolveReport): Seq[ModuleID] =
-    confReport.getEvictedNodes.map(node => toModuleID(node.getId))
+    ArraySeq.unsafeWrapArray(confReport.getEvictedNodes).map(node => toModuleID(node.getId))
 
   def toModuleID(revID: ModuleRevisionId): ModuleID =
     ModuleID(revID.getOrganisation, revID.getName, revID.getRevision)

--- a/ivy/src/main/scala/sbt/internal/librarymanagement/ivyint/CachedResolutionResolveEngine.scala
+++ b/ivy/src/main/scala/sbt/internal/librarymanagement/ivyint/CachedResolutionResolveEngine.scala
@@ -159,9 +159,8 @@ private[sbt] class CachedResolutionResolveCache {
   }
   def extractOverrides(md0: ModuleDescriptor): Vector[IvyOverride] = {
     import scala.jdk.CollectionConverters._
-    md0.getAllDependencyDescriptorMediators.getAllRules.asScala.toSeq.toVector sortBy {
-      case (k, _) =>
-        k.toString
+    md0.getAllDependencyDescriptorMediators.getAllRules.asScala.toVector sortBy { case (k, _) =>
+      k.toString
     } collect { case (k: MapMatcher, v: OverrideDependencyDescriptorMediator) =>
       val attr: Map[Any, Any] = k.getAttributes.asScala.toMap
       val module = IvyModuleId.newInstance(
@@ -398,13 +397,14 @@ private[sbt] trait CachedResolutionResolveEngine extends ResolveEngine {
             doWorkUsingIvy(md)
         }
       def doWorkUsingIvy(md: ModuleDescriptor): Either[ResolveException, UpdateReport] = {
+        import scala.jdk.CollectionConverters._
         val options1 = new ResolveOptions(options0)
         val rr = withIvy(log) { ivy =>
           ivy.resolve(md, options1)
         }
         if (!rr.hasError || missingOk) Right(IvyRetrieve.updateReport(rr, cachedDescriptor))
         else {
-          val messages = rr.getAllProblemMessages.toArray.map(_.toString).distinct
+          val messages = rr.getAllProblemMessages.asScala.toSeq.map(_.toString).distinct
           val failedPaths = ListMap(rr.getUnresolvedDependencies map { node =>
             val m = IvyRetrieve.toModuleID(node.getId)
             val path = IvyRetrieve.findPath(node, md.getModuleRevisionId) map { x =>
@@ -781,7 +781,7 @@ private[sbt] trait CachedResolutionResolveEngine extends ResolveEngine {
     }
     val merged = (modules groupBy { m =>
       (m.module.organization, m.module.name, m.module.revision)
-    }).toSeq.toVector flatMap { case (_, xs) =>
+    }).toVector flatMap { case (_, xs) =>
       if (xs.size < 2) xs
       else Vector(mergeModuleReports(xs))
     }

--- a/ivy/src/main/scala/sbt/internal/librarymanagement/ivyint/CachedResolutionResolveEngine.scala
+++ b/ivy/src/main/scala/sbt/internal/librarymanagement/ivyint/CachedResolutionResolveEngine.scala
@@ -937,7 +937,7 @@ private[sbt] trait CachedResolutionResolveEngine extends ResolveEngine {
                 }).mkString("(", ", ", ")")
               )
           }
-        case None =>
+        case _ =>
           getSettings.getConflictManager(IvyModuleId.newInstance(organization, name)) match {
             case ncm: NoConflictManager => (conflicts, Vector(), ncm.toString)
             case _: StrictConflictManager =>

--- a/ivy/src/main/scala/sbt/internal/librarymanagement/ivyint/MergeDescriptors.scala
+++ b/ivy/src/main/scala/sbt/internal/librarymanagement/ivyint/MergeDescriptors.scala
@@ -1,6 +1,7 @@
 package sbt.internal.librarymanagement
 package ivyint
 
+import scala.collection.immutable.ArraySeq
 import org.apache.ivy.core
 import core.module.descriptor.{ DependencyArtifactDescriptor, DefaultDependencyArtifactDescriptor }
 import core.module.descriptor.DependencyDescriptor
@@ -117,7 +118,7 @@ private[sbt] final case class MergedDescriptors(a: DependencyDescriptor, b: Depe
     // See gh-1500, gh-2002
     aConfs match {
       case None | Some(Nil) | Some(List("*")) =>
-        copyWithConfigurations(art, base.getModuleConfigurations)
+        copyWithConfigurations(art, ArraySeq.unsafeWrapArray(base.getModuleConfigurations))
       case _ => art
     }
   }
@@ -132,7 +133,7 @@ private[sbt] final case class MergedDescriptors(a: DependencyDescriptor, b: Depe
       null,
       null
     )
-    addConfigurations(dd, a.getModuleConfigurations)
+    addConfigurations(dd, ArraySeq.unsafeWrapArray(a.getModuleConfigurations))
     // If the dependency descriptor is empty, then it means that it has been created from a POM file. In this case,
     // it is correct to create a seemingly non-existent dependency artifact.
     if (a.getAllDependencyArtifacts.isEmpty) Array(dd)

--- a/ivy/src/main/scala/sbt/internal/librarymanagement/mavenint/PomExtraDependencyAttributes.scala
+++ b/ivy/src/main/scala/sbt/internal/librarymanagement/mavenint/PomExtraDependencyAttributes.scala
@@ -1,6 +1,7 @@
 package sbt.internal.librarymanagement
 package mavenint
 
+import scala.collection.immutable.ArraySeq
 import java.util.Properties
 import java.util.regex.Pattern
 
@@ -100,8 +101,9 @@ object PomExtraDependencyAttributes {
   }
 
   /** parses the sequence of dependencies with extra attribute information, with one dependency per line */
-  def readDependencyExtra(s: String): Seq[ModuleRevisionId] =
+  def readDependencyExtra(s: String): Seq[ModuleRevisionId] = ArraySeq.unsafeWrapArray(
     LinesP.split(s).map(_.trim).filter(!_.isEmpty).map(ModuleRevisionId.decode)
+  )
 
   private[this] val LinesP = Pattern.compile("(?m)^")
 


### PR DESCRIPTION
Fixes warnings:
* fix array conversions warnings 
  * `method copyArrayToImmutableIndexedSeq in class LowPriorityImplicits2 is deprecated since 2.13.0: implicit conversions from Array to immutable.IndexedSeq are implemented by copying; use `toIndexedSeq` explicitly if you want to copy, or use the more efficient non-copying ArraySeq.unsafeWrapArray`
* fix Infinite loop in function body warning
* fix indentation warnings
* fix match warning
* fix warning reflectiveCalls warning by fixing `TODO` 
  * `method reflectiveSelectableFromLangReflectiveCalls in object Selectable is deprecated since 3.0: import scala.reflect.Selectable.reflectiveSelectable instead of scala.language.reflectiveCalls`