### PR TITLE
[2.x] upgrade and reenable sbt'contraband plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -274,7 +274,7 @@ lazy val lmCore = (project in file("core"))
   .configure(addSbtIO, addSbtUtilLogging, addSbtUtilPosition, addSbtUtilCache, addSbtCompilerInterface)
 
 lazy val lmIvy = (project in file("ivy"))
-  // .enablePlugins(ContrabandPlugin, JsonCodecPlugin)
+  .enablePlugins(ContrabandPlugin, JsonCodecPlugin)
   .dependsOn(lmCore)
   .settings(
     commonSettings,

--- a/build.sbt
+++ b/build.sbt
@@ -111,7 +111,7 @@ lazy val lmRoot = (project in file("."))
   )
 
 lazy val lmCore = (project in file("core"))
-  // .enablePlugins(ContrabandPlugin, JsonCodecPlugin)
+  .enablePlugins(ContrabandPlugin, JsonCodecPlugin)
   .settings(
     commonSettings,
     name := "librarymanagement-core",

--- a/build.sbt
+++ b/build.sbt
@@ -143,7 +143,7 @@ lazy val lmCore = (project in file("core"))
       case v if v.startsWith("2.12.") => List("-Ywarn-unused:-locals,-explicits,-privates")
       case _                          => List()
     }),
-    Compile / unmanagedSourceDirectories +=
+    Compile / managedSourceDirectories +=
       baseDirectory.value / "src" / "main" / "contraband-scala",
     Compile / generateContrabands / sourceManaged := baseDirectory.value / "src" / "main" / "contraband-scala",
     Compile / generateContrabands / contrabandFormatsForType := DatatypeConfig.getFormats,
@@ -288,7 +288,7 @@ lazy val lmIvy = (project in file("ivy"))
       scalaCheck % Test,
       scalaVerify % Test,
     ),
-    Compile / unmanagedSourceDirectories +=
+    Compile / managedSourceDirectories +=
       baseDirectory.value / "src" / "main" / "contraband-scala",
     Compile / generateContrabands / sourceManaged := baseDirectory.value / "src" / "main" / "contraband-scala",
     Compile / generateContrabands / contrabandFormatsForType := DatatypeConfig.getFormats,

--- a/core/src/main/contraband-scala/sbt/internal/librarymanagement/ConfigurationReportLite.scala
+++ b/core/src/main/contraband-scala/sbt/internal/librarymanagement/ConfigurationReportLite.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY
@@ -20,7 +20,7 @@ final class ConfigurationReportLite private (
   override def toString: String = {
     "ConfigurationReportLite(" + configuration + ", " + details + ")"
   }
-  private[this] def copy(configuration: String = configuration, details: Vector[sbt.librarymanagement.OrganizationArtifactReport] = details): ConfigurationReportLite = {
+  private def copy(configuration: String = configuration, details: Vector[sbt.librarymanagement.OrganizationArtifactReport] = details): ConfigurationReportLite = {
     new ConfigurationReportLite(configuration, details)
   }
   def withConfiguration(configuration: String): ConfigurationReportLite = {

--- a/core/src/main/contraband-scala/sbt/internal/librarymanagement/SemComparator.scala
+++ b/core/src/main/contraband-scala/sbt/internal/librarymanagement/SemComparator.scala
@@ -12,15 +12,15 @@ final class SemComparator private (
   val tags: Seq[String]) extends sbt.internal.librarymanagement.SemComparatorExtra with Serializable {
   def matches(version: sbt.librarymanagement.VersionNumber): Boolean = this.matchesImpl(version)
   def expandWildcard: Seq[SemComparator] = {
-    if (op == sbt.internal.librarymanagement.SemSelOperator.Eq && !allFieldsSpecified) {
-      Seq(
-        this.withOp(sbt.internal.librarymanagement.SemSelOperator.Gte),
-        this.withOp(sbt.internal.librarymanagement.SemSelOperator.Lte)
-      )
-    } else { Seq(this) }
+    if (op == sbt.internal.librarymanagement.SemSelOperator.Eq && !allFieldsSpecified)
+    Seq(
+    this.withOp(sbt.internal.librarymanagement.SemSelOperator.Gte),
+    this.withOp(sbt.internal.librarymanagement.SemSelOperator.Lte)
+    )
+    else Seq(this)
   }
-
-
+  
+  
   override def equals(o: Any): Boolean = this.eq(o.asInstanceOf[AnyRef]) || (o match {
     case x: SemComparator => (this.op == x.op) && (this.major == x.major) && (this.minor == x.minor) && (this.patch == x.patch) && (this.tags == x.tags)
     case _ => false

--- a/core/src/main/contraband-scala/sbt/internal/librarymanagement/SemComparator.scala
+++ b/core/src/main/contraband-scala/sbt/internal/librarymanagement/SemComparator.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY
@@ -31,7 +31,7 @@ final class SemComparator private (
   override def toString: String = {
     this.toStringImpl
   }
-  private[this] def copy(op: sbt.internal.librarymanagement.SemSelOperator = op, major: Option[Long] = major, minor: Option[Long] = minor, patch: Option[Long] = patch, tags: Seq[String] = tags): SemComparator = {
+  private def copy(op: sbt.internal.librarymanagement.SemSelOperator = op, major: Option[Long] = major, minor: Option[Long] = minor, patch: Option[Long] = patch, tags: Seq[String] = tags): SemComparator = {
     new SemComparator(op, major, minor, patch, tags)
   }
   def withOp(op: sbt.internal.librarymanagement.SemSelOperator): SemComparator = {

--- a/core/src/main/contraband-scala/sbt/internal/librarymanagement/SemSelAndChunk.scala
+++ b/core/src/main/contraband-scala/sbt/internal/librarymanagement/SemSelAndChunk.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY
@@ -19,7 +19,7 @@ final class SemSelAndChunk private (
   override def toString: String = {
     comparators.map(_.toString).mkString(" ")
   }
-  private[this] def copy(comparators: Seq[sbt.internal.librarymanagement.SemComparator] = comparators): SemSelAndChunk = {
+  private def copy(comparators: Seq[sbt.internal.librarymanagement.SemComparator] = comparators): SemSelAndChunk = {
     new SemSelAndChunk(comparators)
   }
   def withComparators(comparators: Seq[sbt.internal.librarymanagement.SemComparator]): SemSelAndChunk = {

--- a/core/src/main/contraband-scala/sbt/internal/librarymanagement/UpdateReportLite.scala
+++ b/core/src/main/contraband-scala/sbt/internal/librarymanagement/UpdateReportLite.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY
@@ -19,7 +19,7 @@ final class UpdateReportLite private (
   override def toString: String = {
     "UpdateReportLite(" + configurations + ")"
   }
-  private[this] def copy(configurations: Vector[sbt.internal.librarymanagement.ConfigurationReportLite] = configurations): UpdateReportLite = {
+  private def copy(configurations: Vector[sbt.internal.librarymanagement.ConfigurationReportLite] = configurations): UpdateReportLite = {
     new UpdateReportLite(configurations)
   }
   def withConfigurations(configurations: Vector[sbt.internal.librarymanagement.ConfigurationReportLite]): UpdateReportLite = {

--- a/core/src/main/contraband-scala/sbt/librarymanagement/Artifact.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/Artifact.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY
@@ -28,7 +28,7 @@ final class Artifact private (
   override def toString: String = {
     "Artifact(" + name + ", " + `type` + ", " + extension + ", " + classifier + ", " + configurations + ", " + url + ", " + extraAttributes + ", " + checksum + ", " + allowInsecureProtocol + ")"
   }
-  private[this] def copy(name: String = name, `type`: String = `type`, extension: String = extension, classifier: Option[String] = classifier, configurations: Vector[sbt.librarymanagement.ConfigRef] = configurations, url: Option[java.net.URI] = url, extraAttributes: Map[String, String] = extraAttributes, checksum: Option[sbt.librarymanagement.Checksum] = checksum, allowInsecureProtocol: Boolean = allowInsecureProtocol): Artifact = {
+  private def copy(name: String = name, `type`: String = `type`, extension: String = extension, classifier: Option[String] = classifier, configurations: Vector[sbt.librarymanagement.ConfigRef] = configurations, url: Option[java.net.URI] = url, extraAttributes: Map[String, String] = extraAttributes, checksum: Option[sbt.librarymanagement.Checksum] = checksum, allowInsecureProtocol: Boolean = allowInsecureProtocol): Artifact = {
     new Artifact(name, `type`, extension, classifier, configurations, url, extraAttributes, checksum, allowInsecureProtocol)
   }
   def withName(name: String): Artifact = {

--- a/core/src/main/contraband-scala/sbt/librarymanagement/ArtifactFormats.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/ArtifactFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/ArtifactTypeFilter.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/ArtifactTypeFilter.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY
@@ -27,7 +27,7 @@ final class ArtifactTypeFilter private (
   override def toString: String = {
     "ArtifactTypeFilter(" + types + ", " + inverted + ")"
   }
-  private[this] def copy(types: Set[String] = types, inverted: Boolean = inverted): ArtifactTypeFilter = {
+  private def copy(types: Set[String] = types, inverted: Boolean = inverted): ArtifactTypeFilter = {
     new ArtifactTypeFilter(types, inverted)
   }
   def withTypes(types: Set[String]): ArtifactTypeFilter = {

--- a/core/src/main/contraband-scala/sbt/librarymanagement/ArtifactTypeFilterFormats.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/ArtifactTypeFilterFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/Caller.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/Caller.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY
@@ -25,7 +25,7 @@ final class Caller private (
   override def toString: String = {
     s"$caller"
   }
-  private[this] def copy(caller: sbt.librarymanagement.ModuleID = caller, callerConfigurations: Vector[sbt.librarymanagement.ConfigRef] = callerConfigurations, callerExtraAttributes: Map[String, String] = callerExtraAttributes, isForceDependency: Boolean = isForceDependency, isChangingDependency: Boolean = isChangingDependency, isTransitiveDependency: Boolean = isTransitiveDependency, isDirectlyForceDependency: Boolean = isDirectlyForceDependency): Caller = {
+  private def copy(caller: sbt.librarymanagement.ModuleID = caller, callerConfigurations: Vector[sbt.librarymanagement.ConfigRef] = callerConfigurations, callerExtraAttributes: Map[String, String] = callerExtraAttributes, isForceDependency: Boolean = isForceDependency, isChangingDependency: Boolean = isChangingDependency, isTransitiveDependency: Boolean = isTransitiveDependency, isDirectlyForceDependency: Boolean = isDirectlyForceDependency): Caller = {
     new Caller(caller, callerConfigurations, callerExtraAttributes, isForceDependency, isChangingDependency, isTransitiveDependency, isDirectlyForceDependency)
   }
   def withCaller(caller: sbt.librarymanagement.ModuleID): Caller = {

--- a/core/src/main/contraband-scala/sbt/librarymanagement/CallerFormats.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/CallerFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/ChainedResolver.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/ChainedResolver.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY
@@ -20,7 +20,7 @@ final class ChainedResolver private (
   override def toString: String = {
     "ChainedResolver(" + name + ", " + resolvers + ")"
   }
-  private[this] def copy(name: String = name, resolvers: Vector[sbt.librarymanagement.Resolver] = resolvers): ChainedResolver = {
+  private def copy(name: String = name, resolvers: Vector[sbt.librarymanagement.Resolver] = resolvers): ChainedResolver = {
     new ChainedResolver(name, resolvers)
   }
   def withName(name: String): ChainedResolver = {

--- a/core/src/main/contraband-scala/sbt/librarymanagement/ChainedResolverFormats.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/ChainedResolverFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/Checksum.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/Checksum.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY
@@ -20,7 +20,7 @@ final class Checksum private (
   override def toString: String = {
     "Checksum(" + digest + ", " + `type` + ")"
   }
-  private[this] def copy(digest: String = digest, `type`: String = `type`): Checksum = {
+  private def copy(digest: String = digest, `type`: String = `type`): Checksum = {
     new Checksum(digest, `type`)
   }
   def withDigest(digest: String): Checksum = {

--- a/core/src/main/contraband-scala/sbt/librarymanagement/ChecksumFormats.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/ChecksumFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/ConfigurationReport.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/ConfigurationReport.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY
@@ -29,7 +29,7 @@ final class ConfigurationReport private (
     (if (details.isEmpty) modules.mkString + details.flatMap(_.modules).filter(_.evicted).map("\t\t(EVICTED) " + _ + "\n").mkString
     else details.mkString)
   }
-  private[this] def copy(configuration: sbt.librarymanagement.ConfigRef = configuration, modules: Vector[sbt.librarymanagement.ModuleReport] = modules, details: Vector[sbt.librarymanagement.OrganizationArtifactReport] = details): ConfigurationReport = {
+  private def copy(configuration: sbt.librarymanagement.ConfigRef = configuration, modules: Vector[sbt.librarymanagement.ModuleReport] = modules, details: Vector[sbt.librarymanagement.OrganizationArtifactReport] = details): ConfigurationReport = {
     new ConfigurationReport(configuration, modules, details)
   }
   def withConfiguration(configuration: sbt.librarymanagement.ConfigRef): ConfigurationReport = {

--- a/core/src/main/contraband-scala/sbt/librarymanagement/ConfigurationReportFormats.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/ConfigurationReportFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/ConfigurationReportLiteFormats.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/ConfigurationReportLiteFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/ConflictManager.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/ConflictManager.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY
@@ -22,7 +22,7 @@ final class ConflictManager private (
   override def toString: String = {
     "ConflictManager(" + name + ", " + organization + ", " + module + ")"
   }
-  private[this] def copy(name: String = name, organization: String = organization, module: String = module): ConflictManager = {
+  private def copy(name: String = name, organization: String = organization, module: String = module): ConflictManager = {
     new ConflictManager(name, organization, module)
   }
   def withName(name: String): ConflictManager = {

--- a/core/src/main/contraband-scala/sbt/librarymanagement/ConflictManagerFormats.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/ConflictManagerFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/Developer.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/Developer.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY
@@ -22,7 +22,7 @@ final class Developer private (
   override def toString: String = {
     "Developer(" + id + ", " + name + ", " + email + ", " + url + ")"
   }
-  private[this] def copy(id: String = id, name: String = name, email: String = email, url: java.net.URI = url): Developer = {
+  private def copy(id: String = id, name: String = name, email: String = email, url: java.net.URI = url): Developer = {
     new Developer(id, name, email, url)
   }
   def withId(id: String): Developer = {

--- a/core/src/main/contraband-scala/sbt/librarymanagement/DeveloperFormats.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/DeveloperFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/FileConfiguration.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/FileConfiguration.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY
@@ -21,7 +21,7 @@ final class FileConfiguration private (
   override def toString: String = {
     "FileConfiguration(" + isLocal + ", " + isTransactional + ")"
   }
-  private[this] def copy(isLocal: Boolean = isLocal, isTransactional: Option[Boolean] = isTransactional): FileConfiguration = {
+  private def copy(isLocal: Boolean = isLocal, isTransactional: Option[Boolean] = isTransactional): FileConfiguration = {
     new FileConfiguration(isLocal, isTransactional)
   }
   def withIsLocal(isLocal: Boolean): FileConfiguration = {

--- a/core/src/main/contraband-scala/sbt/librarymanagement/FileConfigurationFormats.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/FileConfigurationFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/FileRepository.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/FileRepository.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY
@@ -23,7 +23,7 @@ final class FileRepository private (
   override def toString: String = {
     "FileRepository(" + name + ", " + patterns + ", " + configuration + ")"
   }
-  private[this] def copy(name: String = name, patterns: sbt.librarymanagement.Patterns = patterns, configuration: sbt.librarymanagement.FileConfiguration = configuration): FileRepository = {
+  private def copy(name: String = name, patterns: sbt.librarymanagement.Patterns = patterns, configuration: sbt.librarymanagement.FileConfiguration = configuration): FileRepository = {
     new FileRepository(name, patterns, configuration)
   }
   def withName(name: String): FileRepository = {

--- a/core/src/main/contraband-scala/sbt/librarymanagement/FileRepositoryFormats.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/FileRepositoryFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/GetClassifiersConfiguration.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/GetClassifiersConfiguration.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY
@@ -23,7 +23,7 @@ final class GetClassifiersConfiguration private (
   override def toString: String = {
     "GetClassifiersConfiguration(" + module + ", " + excludes + ", " + updateConfiguration + ", " + sourceArtifactTypes + ", " + docArtifactTypes + ")"
   }
-  private[this] def copy(module: sbt.librarymanagement.GetClassifiersModule = module, excludes: Vector[scala.Tuple2[sbt.librarymanagement.ModuleID, scala.Vector[sbt.librarymanagement.ConfigRef]]] = excludes, updateConfiguration: sbt.librarymanagement.UpdateConfiguration = updateConfiguration, sourceArtifactTypes: Vector[String] = sourceArtifactTypes, docArtifactTypes: Vector[String] = docArtifactTypes): GetClassifiersConfiguration = {
+  private def copy(module: sbt.librarymanagement.GetClassifiersModule = module, excludes: Vector[scala.Tuple2[sbt.librarymanagement.ModuleID, scala.Vector[sbt.librarymanagement.ConfigRef]]] = excludes, updateConfiguration: sbt.librarymanagement.UpdateConfiguration = updateConfiguration, sourceArtifactTypes: Vector[String] = sourceArtifactTypes, docArtifactTypes: Vector[String] = docArtifactTypes): GetClassifiersConfiguration = {
     new GetClassifiersConfiguration(module, excludes, updateConfiguration, sourceArtifactTypes, docArtifactTypes)
   }
   def withModule(module: sbt.librarymanagement.GetClassifiersModule): GetClassifiersConfiguration = {

--- a/core/src/main/contraband-scala/sbt/librarymanagement/GetClassifiersConfigurationFormats.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/GetClassifiersConfigurationFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/GetClassifiersModule.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/GetClassifiersModule.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY
@@ -23,7 +23,7 @@ final class GetClassifiersModule private (
   override def toString: String = {
     "GetClassifiersModule(" + id + ", " + scalaModuleInfo + ", " + dependencies + ", " + configurations + ", " + classifiers + ")"
   }
-  private[this] def copy(id: sbt.librarymanagement.ModuleID = id, scalaModuleInfo: Option[sbt.librarymanagement.ScalaModuleInfo] = scalaModuleInfo, dependencies: Vector[sbt.librarymanagement.ModuleID] = dependencies, configurations: Vector[sbt.librarymanagement.Configuration] = configurations, classifiers: Vector[String] = classifiers): GetClassifiersModule = {
+  private def copy(id: sbt.librarymanagement.ModuleID = id, scalaModuleInfo: Option[sbt.librarymanagement.ScalaModuleInfo] = scalaModuleInfo, dependencies: Vector[sbt.librarymanagement.ModuleID] = dependencies, configurations: Vector[sbt.librarymanagement.Configuration] = configurations, classifiers: Vector[String] = classifiers): GetClassifiersModule = {
     new GetClassifiersModule(id, scalaModuleInfo, dependencies, configurations, classifiers)
   }
   def withId(id: sbt.librarymanagement.ModuleID): GetClassifiersModule = {

--- a/core/src/main/contraband-scala/sbt/librarymanagement/GetClassifiersModuleFormats.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/GetClassifiersModuleFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/InclExclRule.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/InclExclRule.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY
@@ -32,7 +32,7 @@ final class InclExclRule private (
   override def toString: String = {
     "InclExclRule(" + organization + ", " + name + ", " + artifact + ", " + configurations + ", " + crossVersion + ")"
   }
-  private[this] def copy(organization: String = organization, name: String = name, artifact: String = artifact, configurations: Vector[sbt.librarymanagement.ConfigRef] = configurations, crossVersion: sbt.librarymanagement.CrossVersion = crossVersion): InclExclRule = {
+  private def copy(organization: String = organization, name: String = name, artifact: String = artifact, configurations: Vector[sbt.librarymanagement.ConfigRef] = configurations, crossVersion: sbt.librarymanagement.CrossVersion = crossVersion): InclExclRule = {
     new InclExclRule(organization, name, artifact, configurations, crossVersion)
   }
   def withOrganization(organization: String): InclExclRule = {

--- a/core/src/main/contraband-scala/sbt/librarymanagement/InclExclRuleFormats.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/InclExclRuleFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/IvyFileConfiguration.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/IvyFileConfiguration.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY
@@ -22,7 +22,7 @@ final class IvyFileConfiguration private (
   override def toString: String = {
     "IvyFileConfiguration(" + validate + ", " + scalaModuleInfo + ", " + file + ", " + autoScalaTools + ")"
   }
-  private[this] def copy(validate: Boolean = validate, scalaModuleInfo: Option[sbt.librarymanagement.ScalaModuleInfo] = scalaModuleInfo, file: java.io.File = file, autoScalaTools: Boolean = autoScalaTools): IvyFileConfiguration = {
+  private def copy(validate: Boolean = validate, scalaModuleInfo: Option[sbt.librarymanagement.ScalaModuleInfo] = scalaModuleInfo, file: java.io.File = file, autoScalaTools: Boolean = autoScalaTools): IvyFileConfiguration = {
     new IvyFileConfiguration(validate, scalaModuleInfo, file, autoScalaTools)
   }
   def withValidate(validate: Boolean): IvyFileConfiguration = {

--- a/core/src/main/contraband-scala/sbt/librarymanagement/IvyFileConfigurationFormats.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/IvyFileConfigurationFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/KeyFileAuthentication.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/KeyFileAuthentication.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY
@@ -21,7 +21,7 @@ final class KeyFileAuthentication private (
   override def toString: String = {
     "KeyFileAuthentication(" + user + ", " + keyfile + ", " + password + ")"
   }
-  private[this] def copy(user: String = user, keyfile: java.io.File = keyfile, password: Option[String] = password): KeyFileAuthentication = {
+  private def copy(user: String = user, keyfile: java.io.File = keyfile, password: Option[String] = password): KeyFileAuthentication = {
     new KeyFileAuthentication(user, keyfile, password)
   }
   def withUser(user: String): KeyFileAuthentication = {

--- a/core/src/main/contraband-scala/sbt/librarymanagement/KeyFileAuthenticationFormats.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/KeyFileAuthenticationFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/LibraryManagementCodec.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/LibraryManagementCodec.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/MakePomConfiguration.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/MakePomConfiguration.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY
@@ -26,7 +26,7 @@ final class MakePomConfiguration private (
   override def toString: String = {
     "MakePomConfiguration(" + file + ", " + moduleInfo + ", " + configurations + ", " + extra + ", " + process + ", " + filterRepositories + ", " + allRepositories + ", " + includeTypes + ")"
   }
-  private[this] def copy(file: Option[java.io.File] = file, moduleInfo: Option[sbt.librarymanagement.ModuleInfo] = moduleInfo, configurations: Option[scala.Vector[sbt.librarymanagement.Configuration]] = configurations, extra: Option[scala.xml.NodeSeq] = extra, process: scala.Function1[scala.xml.Node, scala.xml.Node] = process, filterRepositories: scala.Function1[sbt.librarymanagement.MavenRepository, Boolean] = filterRepositories, allRepositories: Boolean = allRepositories, includeTypes: Set[String] = includeTypes): MakePomConfiguration = {
+  private def copy(file: Option[java.io.File] = file, moduleInfo: Option[sbt.librarymanagement.ModuleInfo] = moduleInfo, configurations: Option[scala.Vector[sbt.librarymanagement.Configuration]] = configurations, extra: Option[scala.xml.NodeSeq] = extra, process: scala.Function1[scala.xml.Node, scala.xml.Node] = process, filterRepositories: scala.Function1[sbt.librarymanagement.MavenRepository, Boolean] = filterRepositories, allRepositories: Boolean = allRepositories, includeTypes: Set[String] = includeTypes): MakePomConfiguration = {
     new MakePomConfiguration(file, moduleInfo, configurations, extra, process, filterRepositories, allRepositories, includeTypes)
   }
   def withFile(file: Option[java.io.File]): MakePomConfiguration = {

--- a/core/src/main/contraband-scala/sbt/librarymanagement/MavenCache.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/MavenCache.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY
@@ -28,7 +28,7 @@ final class MavenCache private (
   override def toString: String = {
     s"cache:$name: ${rootFile.getAbsolutePath}"
   }
-  private[this] def copy(name: String = name, root: String = root, localIfFile: Boolean = localIfFile, rootFile: java.io.File = rootFile): MavenCache = {
+  private def copy(name: String = name, root: String = root, localIfFile: Boolean = localIfFile, rootFile: java.io.File = rootFile): MavenCache = {
     new MavenCache(name, root, localIfFile, rootFile)
   }
   def withName(name: String): MavenCache = {

--- a/core/src/main/contraband-scala/sbt/librarymanagement/MavenCacheFormats.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/MavenCacheFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/MavenRepo.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/MavenRepo.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY
@@ -26,7 +26,7 @@ final class MavenRepo private (
   override def toString: String = {
     s"$name: $root"
   }
-  private[this] def copy(name: String = name, root: String = root, localIfFile: Boolean = localIfFile, _allowInsecureProtocol: Boolean = _allowInsecureProtocol): MavenRepo = {
+  private def copy(name: String = name, root: String = root, localIfFile: Boolean = localIfFile, _allowInsecureProtocol: Boolean = _allowInsecureProtocol): MavenRepo = {
     new MavenRepo(name, root, localIfFile, _allowInsecureProtocol)
   }
   def withName(name: String): MavenRepo = {

--- a/core/src/main/contraband-scala/sbt/librarymanagement/MavenRepoFormats.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/MavenRepoFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/MavenRepository.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/MavenRepository.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/MavenRepositoryFormats.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/MavenRepositoryFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/ModuleConfiguration.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/ModuleConfiguration.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY
@@ -22,7 +22,7 @@ final class ModuleConfiguration private (
   override def toString: String = {
     "ModuleConfiguration(" + organization + ", " + name + ", " + revision + ", " + resolver + ")"
   }
-  private[this] def copy(organization: String = organization, name: String = name, revision: String = revision, resolver: sbt.librarymanagement.Resolver = resolver): ModuleConfiguration = {
+  private def copy(organization: String = organization, name: String = name, revision: String = revision, resolver: sbt.librarymanagement.Resolver = resolver): ModuleConfiguration = {
     new ModuleConfiguration(organization, name, revision, resolver)
   }
   def withOrganization(organization: String): ModuleConfiguration = {

--- a/core/src/main/contraband-scala/sbt/librarymanagement/ModuleConfigurationFormats.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/ModuleConfigurationFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/ModuleDescriptorConfiguration.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/ModuleDescriptorConfiguration.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY
@@ -29,7 +29,7 @@ final class ModuleDescriptorConfiguration private (
   override def toString: String = {
     "ModuleDescriptorConfiguration(" + validate + ", " + scalaModuleInfo + ", " + module + ", " + moduleInfo + ", " + dependencies + ", " + overrides + ", " + excludes + ", " + ivyXML + ", " + configurations + ", " + defaultConfiguration + ", " + conflictManager + ")"
   }
-  private[this] def copy(validate: Boolean = validate, scalaModuleInfo: Option[sbt.librarymanagement.ScalaModuleInfo] = scalaModuleInfo, module: sbt.librarymanagement.ModuleID = module, moduleInfo: sbt.librarymanagement.ModuleInfo = moduleInfo, dependencies: Vector[sbt.librarymanagement.ModuleID] = dependencies, overrides: Vector[sbt.librarymanagement.ModuleID] = overrides, excludes: Vector[sbt.librarymanagement.InclExclRule] = excludes, ivyXML: scala.xml.NodeSeq = ivyXML, configurations: Vector[sbt.librarymanagement.Configuration] = configurations, defaultConfiguration: Option[sbt.librarymanagement.Configuration] = defaultConfiguration, conflictManager: sbt.librarymanagement.ConflictManager = conflictManager): ModuleDescriptorConfiguration = {
+  private def copy(validate: Boolean = validate, scalaModuleInfo: Option[sbt.librarymanagement.ScalaModuleInfo] = scalaModuleInfo, module: sbt.librarymanagement.ModuleID = module, moduleInfo: sbt.librarymanagement.ModuleInfo = moduleInfo, dependencies: Vector[sbt.librarymanagement.ModuleID] = dependencies, overrides: Vector[sbt.librarymanagement.ModuleID] = overrides, excludes: Vector[sbt.librarymanagement.InclExclRule] = excludes, ivyXML: scala.xml.NodeSeq = ivyXML, configurations: Vector[sbt.librarymanagement.Configuration] = configurations, defaultConfiguration: Option[sbt.librarymanagement.Configuration] = defaultConfiguration, conflictManager: sbt.librarymanagement.ConflictManager = conflictManager): ModuleDescriptorConfiguration = {
     new ModuleDescriptorConfiguration(validate, scalaModuleInfo, module, moduleInfo, dependencies, overrides, excludes, ivyXML, configurations, defaultConfiguration, conflictManager)
   }
   def withValidate(validate: Boolean): ModuleDescriptorConfiguration = {

--- a/core/src/main/contraband-scala/sbt/librarymanagement/ModuleDescriptorConfigurationFormats.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/ModuleDescriptorConfigurationFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/ModuleID.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/ModuleID.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY
@@ -33,7 +33,7 @@ final class ModuleID private (
   override def toString: String = {
     this.toStringImpl
   }
-  private[this] def copy(organization: String = organization, name: String = name, revision: String = revision, configurations: Option[String] = configurations, isChanging: Boolean = isChanging, isTransitive: Boolean = isTransitive, isForce: Boolean = isForce, explicitArtifacts: Vector[sbt.librarymanagement.Artifact] = explicitArtifacts, inclusions: Vector[sbt.librarymanagement.InclExclRule] = inclusions, exclusions: Vector[sbt.librarymanagement.InclExclRule] = exclusions, extraAttributes: Map[String, String] = extraAttributes, crossVersion: sbt.librarymanagement.CrossVersion = crossVersion, branchName: Option[String] = branchName, platformOpt: Option[String] = platformOpt): ModuleID = {
+  private def copy(organization: String = organization, name: String = name, revision: String = revision, configurations: Option[String] = configurations, isChanging: Boolean = isChanging, isTransitive: Boolean = isTransitive, isForce: Boolean = isForce, explicitArtifacts: Vector[sbt.librarymanagement.Artifact] = explicitArtifacts, inclusions: Vector[sbt.librarymanagement.InclExclRule] = inclusions, exclusions: Vector[sbt.librarymanagement.InclExclRule] = exclusions, extraAttributes: Map[String, String] = extraAttributes, crossVersion: sbt.librarymanagement.CrossVersion = crossVersion, branchName: Option[String] = branchName, platformOpt: Option[String] = platformOpt): ModuleID = {
     new ModuleID(organization, name, revision, configurations, isChanging, isTransitive, isForce, explicitArtifacts, inclusions, exclusions, extraAttributes, crossVersion, branchName, platformOpt)
   }
   def withOrganization(organization: String): ModuleID = {

--- a/core/src/main/contraband-scala/sbt/librarymanagement/ModuleIDFormats.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/ModuleIDFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/ModuleInfo.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/ModuleInfo.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY
@@ -28,7 +28,7 @@ final class ModuleInfo private (
   override def toString: String = {
     "ModuleInfo(" + nameFormal + ", " + description + ", " + homepage + ", " + startYear + ", " + licenses + ", " + organizationName + ", " + organizationHomepage + ", " + scmInfo + ", " + developers + ")"
   }
-  private[this] def copy(nameFormal: String = nameFormal, description: String = description, homepage: Option[java.net.URI] = homepage, startYear: Option[Int] = startYear, licenses: Vector[scala.Tuple2[String, java.net.URI]] = licenses, organizationName: String = organizationName, organizationHomepage: Option[java.net.URI] = organizationHomepage, scmInfo: Option[sbt.librarymanagement.ScmInfo] = scmInfo, developers: Vector[sbt.librarymanagement.Developer] = developers): ModuleInfo = {
+  private def copy(nameFormal: String = nameFormal, description: String = description, homepage: Option[java.net.URI] = homepage, startYear: Option[Int] = startYear, licenses: Vector[scala.Tuple2[String, java.net.URI]] = licenses, organizationName: String = organizationName, organizationHomepage: Option[java.net.URI] = organizationHomepage, scmInfo: Option[sbt.librarymanagement.ScmInfo] = scmInfo, developers: Vector[sbt.librarymanagement.Developer] = developers): ModuleInfo = {
     new ModuleInfo(nameFormal, description, homepage, startYear, licenses, organizationName, organizationHomepage, scmInfo, developers)
   }
   def withNameFormal(nameFormal: String): ModuleInfo = {

--- a/core/src/main/contraband-scala/sbt/librarymanagement/ModuleInfoFormats.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/ModuleInfoFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/ModuleReport.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/ModuleReport.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY
@@ -41,7 +41,7 @@ final class ModuleReport private (
     s"\t\t$module: " +
     (if (arts.size <= 1) "" else "\n\t\t\t") + arts.mkString("\n\t\t\t") + "\n"
   }
-  private[this] def copy(module: sbt.librarymanagement.ModuleID = module, artifacts: Vector[scala.Tuple2[sbt.librarymanagement.Artifact, java.io.File]] = artifacts, missingArtifacts: Vector[sbt.librarymanagement.Artifact] = missingArtifacts, status: Option[String] = status, publicationDate: Option[java.util.Calendar] = publicationDate, resolver: Option[String] = resolver, artifactResolver: Option[String] = artifactResolver, evicted: Boolean = evicted, evictedData: Option[String] = evictedData, evictedReason: Option[String] = evictedReason, problem: Option[String] = problem, homepage: Option[String] = homepage, extraAttributes: Map[String, String] = extraAttributes, isDefault: Option[Boolean] = isDefault, branch: Option[String] = branch, configurations: Vector[sbt.librarymanagement.ConfigRef] = configurations, licenses: Vector[scala.Tuple2[String, Option[String]]] = licenses, callers: Vector[sbt.librarymanagement.Caller] = callers): ModuleReport = {
+  private def copy(module: sbt.librarymanagement.ModuleID = module, artifacts: Vector[scala.Tuple2[sbt.librarymanagement.Artifact, java.io.File]] = artifacts, missingArtifacts: Vector[sbt.librarymanagement.Artifact] = missingArtifacts, status: Option[String] = status, publicationDate: Option[java.util.Calendar] = publicationDate, resolver: Option[String] = resolver, artifactResolver: Option[String] = artifactResolver, evicted: Boolean = evicted, evictedData: Option[String] = evictedData, evictedReason: Option[String] = evictedReason, problem: Option[String] = problem, homepage: Option[String] = homepage, extraAttributes: Map[String, String] = extraAttributes, isDefault: Option[Boolean] = isDefault, branch: Option[String] = branch, configurations: Vector[sbt.librarymanagement.ConfigRef] = configurations, licenses: Vector[scala.Tuple2[String, Option[String]]] = licenses, callers: Vector[sbt.librarymanagement.Caller] = callers): ModuleReport = {
     new ModuleReport(module, artifacts, missingArtifacts, status, publicationDate, resolver, artifactResolver, evicted, evictedData, evictedReason, problem, homepage, extraAttributes, isDefault, branch, configurations, licenses, callers)
   }
   def withModule(module: sbt.librarymanagement.ModuleID): ModuleReport = {

--- a/core/src/main/contraband-scala/sbt/librarymanagement/ModuleReportFormats.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/ModuleReportFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/ModuleSettings.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/ModuleSettings.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/ModuleSettingsFormats.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/ModuleSettingsFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/OrganizationArtifactReport.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/OrganizationArtifactReport.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY
@@ -33,7 +33,7 @@ final class OrganizationArtifactReport private (
     val details = modules map { _.detailReport }
     s"\t$organization:$name\n${details.mkString}\n"
   }
-  private[this] def copy(organization: String = organization, name: String = name, modules: Vector[sbt.librarymanagement.ModuleReport] = modules): OrganizationArtifactReport = {
+  private def copy(organization: String = organization, name: String = name, modules: Vector[sbt.librarymanagement.ModuleReport] = modules): OrganizationArtifactReport = {
     new OrganizationArtifactReport(organization, name, modules)
   }
   def withOrganization(organization: String): OrganizationArtifactReport = {

--- a/core/src/main/contraband-scala/sbt/librarymanagement/OrganizationArtifactReportFormats.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/OrganizationArtifactReportFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/PasswordAuthentication.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/PasswordAuthentication.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY
@@ -20,7 +20,7 @@ final class PasswordAuthentication private (
   override def toString: String = {
     "PasswordAuthentication(" + user + ", " + password + ")"
   }
-  private[this] def copy(user: String = user, password: Option[String] = password): PasswordAuthentication = {
+  private def copy(user: String = user, password: Option[String] = password): PasswordAuthentication = {
     new PasswordAuthentication(user, password)
   }
   def withUser(user: String): PasswordAuthentication = {

--- a/core/src/main/contraband-scala/sbt/librarymanagement/PasswordAuthenticationFormats.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/PasswordAuthenticationFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/Patterns.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/Patterns.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY
@@ -24,7 +24,7 @@ final class Patterns private (
     "Patterns(ivyPatterns=%s, artifactPatterns=%s, isMavenCompatible=%s, descriptorOptional=%s, skipConsistencyCheck=%s)".format(
     ivyPatterns, artifactPatterns, isMavenCompatible, descriptorOptional, skipConsistencyCheck)
   }
-  private[this] def copy(ivyPatterns: Vector[String] = ivyPatterns, artifactPatterns: Vector[String] = artifactPatterns, isMavenCompatible: Boolean = isMavenCompatible, descriptorOptional: Boolean = descriptorOptional, skipConsistencyCheck: Boolean = skipConsistencyCheck): Patterns = {
+  private def copy(ivyPatterns: Vector[String] = ivyPatterns, artifactPatterns: Vector[String] = artifactPatterns, isMavenCompatible: Boolean = isMavenCompatible, descriptorOptional: Boolean = descriptorOptional, skipConsistencyCheck: Boolean = skipConsistencyCheck): Patterns = {
     new Patterns(ivyPatterns, artifactPatterns, isMavenCompatible, descriptorOptional, skipConsistencyCheck)
   }
   def withIvyPatterns(ivyPatterns: Vector[String]): Patterns = {

--- a/core/src/main/contraband-scala/sbt/librarymanagement/PatternsBasedRepository.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/PatternsBasedRepository.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/PatternsBasedRepositoryFormats.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/PatternsBasedRepositoryFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/PatternsFormats.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/PatternsFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/PomConfiguration.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/PomConfiguration.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY
@@ -22,7 +22,7 @@ final class PomConfiguration private (
   override def toString: String = {
     "PomConfiguration(" + validate + ", " + scalaModuleInfo + ", " + file + ", " + autoScalaTools + ")"
   }
-  private[this] def copy(validate: Boolean = validate, scalaModuleInfo: Option[sbt.librarymanagement.ScalaModuleInfo] = scalaModuleInfo, file: java.io.File = file, autoScalaTools: Boolean = autoScalaTools): PomConfiguration = {
+  private def copy(validate: Boolean = validate, scalaModuleInfo: Option[sbt.librarymanagement.ScalaModuleInfo] = scalaModuleInfo, file: java.io.File = file, autoScalaTools: Boolean = autoScalaTools): PomConfiguration = {
     new PomConfiguration(validate, scalaModuleInfo, file, autoScalaTools)
   }
   def withValidate(validate: Boolean): PomConfiguration = {

--- a/core/src/main/contraband-scala/sbt/librarymanagement/PomConfigurationFormats.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/PomConfigurationFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/PublishConfiguration.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/PublishConfiguration.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY
@@ -27,7 +27,7 @@ final class PublishConfiguration private (
   override def toString: String = {
     "PublishConfiguration(" + publishMavenStyle + ", " + deliverIvyPattern + ", " + status + ", " + configurations + ", " + resolverName + ", " + artifacts + ", " + checksums + ", " + logging + ", " + overwrite + ")"
   }
-  private[this] def copy(publishMavenStyle: Boolean = publishMavenStyle, deliverIvyPattern: Option[String] = deliverIvyPattern, status: Option[String] = status, configurations: Option[scala.Vector[sbt.librarymanagement.ConfigRef]] = configurations, resolverName: Option[String] = resolverName, artifacts: Vector[scala.Tuple2[sbt.librarymanagement.Artifact, java.io.File]] = artifacts, checksums: scala.Vector[String] = checksums, logging: Option[sbt.librarymanagement.UpdateLogging] = logging, overwrite: Boolean = overwrite): PublishConfiguration = {
+  private def copy(publishMavenStyle: Boolean = publishMavenStyle, deliverIvyPattern: Option[String] = deliverIvyPattern, status: Option[String] = status, configurations: Option[scala.Vector[sbt.librarymanagement.ConfigRef]] = configurations, resolverName: Option[String] = resolverName, artifacts: Vector[scala.Tuple2[sbt.librarymanagement.Artifact, java.io.File]] = artifacts, checksums: scala.Vector[String] = checksums, logging: Option[sbt.librarymanagement.UpdateLogging] = logging, overwrite: Boolean = overwrite): PublishConfiguration = {
     new PublishConfiguration(publishMavenStyle, deliverIvyPattern, status, configurations, resolverName, artifacts, checksums, logging, overwrite)
   }
   def withPublishMavenStyle(publishMavenStyle: Boolean): PublishConfiguration = {

--- a/core/src/main/contraband-scala/sbt/librarymanagement/PublishConfigurationFormats.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/PublishConfigurationFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/Resolver.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/Resolver.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/ResolverFormats.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/ResolverFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/RetrieveConfiguration.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/RetrieveConfiguration.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY
@@ -23,7 +23,7 @@ final class RetrieveConfiguration private (
   override def toString: String = {
     "RetrieveConfiguration(" + retrieveDirectory + ", " + outputPattern + ", " + sync + ", " + configurationsToRetrieve + ")"
   }
-  private[this] def copy(retrieveDirectory: Option[java.io.File] = retrieveDirectory, outputPattern: Option[String] = outputPattern, sync: Boolean = sync, configurationsToRetrieve: Option[scala.Vector[sbt.librarymanagement.ConfigRef]] = configurationsToRetrieve): RetrieveConfiguration = {
+  private def copy(retrieveDirectory: Option[java.io.File] = retrieveDirectory, outputPattern: Option[String] = outputPattern, sync: Boolean = sync, configurationsToRetrieve: Option[scala.Vector[sbt.librarymanagement.ConfigRef]] = configurationsToRetrieve): RetrieveConfiguration = {
     new RetrieveConfiguration(retrieveDirectory, outputPattern, sync, configurationsToRetrieve)
   }
   def withRetrieveDirectory(retrieveDirectory: Option[java.io.File]): RetrieveConfiguration = {

--- a/core/src/main/contraband-scala/sbt/librarymanagement/RetrieveConfigurationFormats.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/RetrieveConfigurationFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/ScalaModuleInfo.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/ScalaModuleInfo.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY
@@ -28,7 +28,7 @@ final class ScalaModuleInfo private (
   override def toString: String = {
     "ScalaModuleInfo(" + scalaFullVersion + ", " + scalaBinaryVersion + ", " + configurations + ", " + checkExplicit + ", " + filterImplicit + ", " + overrideScalaVersion + ", " + scalaOrganization + ", " + scalaArtifacts + ", " + platform + ")"
   }
-  private[this] def copy(scalaFullVersion: String = scalaFullVersion, scalaBinaryVersion: String = scalaBinaryVersion, configurations: Vector[sbt.librarymanagement.Configuration] = configurations, checkExplicit: Boolean = checkExplicit, filterImplicit: Boolean = filterImplicit, overrideScalaVersion: Boolean = overrideScalaVersion, scalaOrganization: String = scalaOrganization, scalaArtifacts: scala.Vector[String] = scalaArtifacts, platform: Option[String] = platform): ScalaModuleInfo = {
+  private def copy(scalaFullVersion: String = scalaFullVersion, scalaBinaryVersion: String = scalaBinaryVersion, configurations: Vector[sbt.librarymanagement.Configuration] = configurations, checkExplicit: Boolean = checkExplicit, filterImplicit: Boolean = filterImplicit, overrideScalaVersion: Boolean = overrideScalaVersion, scalaOrganization: String = scalaOrganization, scalaArtifacts: scala.Vector[String] = scalaArtifacts, platform: Option[String] = platform): ScalaModuleInfo = {
     new ScalaModuleInfo(scalaFullVersion, scalaBinaryVersion, configurations, checkExplicit, filterImplicit, overrideScalaVersion, scalaOrganization, scalaArtifacts, platform)
   }
   def withScalaFullVersion(scalaFullVersion: String): ScalaModuleInfo = {

--- a/core/src/main/contraband-scala/sbt/librarymanagement/ScalaModuleInfoFormats.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/ScalaModuleInfoFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/ScmInfo.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/ScmInfo.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY
@@ -22,7 +22,7 @@ final class ScmInfo private (
   override def toString: String = {
     "ScmInfo(" + browseUrl + ", " + connection + ", " + devConnection + ")"
   }
-  private[this] def copy(browseUrl: java.net.URI = browseUrl, connection: String = connection, devConnection: Option[String] = devConnection): ScmInfo = {
+  private def copy(browseUrl: java.net.URI = browseUrl, connection: String = connection, devConnection: Option[String] = devConnection): ScmInfo = {
     new ScmInfo(browseUrl, connection, devConnection)
   }
   def withBrowseUrl(browseUrl: java.net.URI): ScmInfo = {

--- a/core/src/main/contraband-scala/sbt/librarymanagement/ScmInfoFormats.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/ScmInfoFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/SemanticSelector.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/SemanticSelector.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY
@@ -73,7 +73,7 @@ final class SemanticSelector private (
   override def toString: String = {
     selectors.map(_.toString).mkString(" || ")
   }
-  private[this] def copy(selectors: Seq[sbt.internal.librarymanagement.SemSelAndChunk] = selectors): SemanticSelector = {
+  private def copy(selectors: Seq[sbt.internal.librarymanagement.SemSelAndChunk] = selectors): SemanticSelector = {
     new SemanticSelector(selectors)
   }
   def withSelectors(selectors: Seq[sbt.internal.librarymanagement.SemSelAndChunk]): SemanticSelector = {

--- a/core/src/main/contraband-scala/sbt/librarymanagement/SftpRepository.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/SftpRepository.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY
@@ -23,7 +23,7 @@ final class SftpRepository private (
   override def toString: String = {
     "SftpRepository(" + name + ", " + patterns + ", " + connection + ")"
   }
-  private[this] def copy(name: String = name, patterns: sbt.librarymanagement.Patterns = patterns, connection: sbt.librarymanagement.SshConnection = connection): SftpRepository = {
+  private def copy(name: String = name, patterns: sbt.librarymanagement.Patterns = patterns, connection: sbt.librarymanagement.SshConnection = connection): SftpRepository = {
     new SftpRepository(name, patterns, connection)
   }
   def withName(name: String): SftpRepository = {

--- a/core/src/main/contraband-scala/sbt/librarymanagement/SftpRepositoryFormats.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/SftpRepositoryFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/SshAuthentication.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/SshAuthentication.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/SshAuthenticationFormats.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/SshAuthenticationFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/SshBasedRepository.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/SshBasedRepository.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/SshBasedRepositoryFormats.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/SshBasedRepositoryFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/SshConnection.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/SshConnection.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY
@@ -21,7 +21,7 @@ final class SshConnection private (
   override def toString: String = {
     "SshConnection(" + authentication + ", " + hostname + ", " + port + ")"
   }
-  private[this] def copy(authentication: Option[sbt.librarymanagement.SshAuthentication] = authentication, hostname: Option[String] = hostname, port: Option[Int] = port): SshConnection = {
+  private def copy(authentication: Option[sbt.librarymanagement.SshAuthentication] = authentication, hostname: Option[String] = hostname, port: Option[Int] = port): SshConnection = {
     new SshConnection(authentication, hostname, port)
   }
   def withAuthentication(authentication: Option[sbt.librarymanagement.SshAuthentication]): SshConnection = {

--- a/core/src/main/contraband-scala/sbt/librarymanagement/SshConnectionFormats.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/SshConnectionFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/SshRepository.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/SshRepository.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY
@@ -24,7 +24,7 @@ final class SshRepository private (
   override def toString: String = {
     "SshRepository(" + name + ", " + patterns + ", " + connection + ", " + publishPermissions + ")"
   }
-  private[this] def copy(name: String = name, patterns: sbt.librarymanagement.Patterns = patterns, connection: sbt.librarymanagement.SshConnection = connection, publishPermissions: Option[String] = publishPermissions): SshRepository = {
+  private def copy(name: String = name, patterns: sbt.librarymanagement.Patterns = patterns, connection: sbt.librarymanagement.SshConnection = connection, publishPermissions: Option[String] = publishPermissions): SshRepository = {
     new SshRepository(name, patterns, connection, publishPermissions)
   }
   def withName(name: String): SshRepository = {

--- a/core/src/main/contraband-scala/sbt/librarymanagement/SshRepositoryFormats.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/SshRepositoryFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/URLRepository.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/URLRepository.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY
@@ -21,7 +21,7 @@ final class URLRepository private (
   override def toString: String = {
     "URLRepository(" + name + ", " + patterns + ", " + allowInsecureProtocol + ")"
   }
-  private[this] def copy(name: String = name, patterns: sbt.librarymanagement.Patterns = patterns, allowInsecureProtocol: Boolean = allowInsecureProtocol): URLRepository = {
+  private def copy(name: String = name, patterns: sbt.librarymanagement.Patterns = patterns, allowInsecureProtocol: Boolean = allowInsecureProtocol): URLRepository = {
     new URLRepository(name, patterns, allowInsecureProtocol)
   }
   def withName(name: String): URLRepository = {

--- a/core/src/main/contraband-scala/sbt/librarymanagement/URLRepositoryFormats.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/URLRepositoryFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/UpdateConfiguration.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/UpdateConfiguration.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY
@@ -35,7 +35,7 @@ final class UpdateConfiguration private (
   override def toString: String = {
     "UpdateConfiguration(" + retrieveManaged + ", " + missingOk + ", " + logging + ", " + logicalClock + ", " + metadataDirectory + ", " + artifactFilter + ", " + offline + ", " + frozen + ")"
   }
-  private[this] def copy(retrieveManaged: Option[sbt.librarymanagement.RetrieveConfiguration] = retrieveManaged, missingOk: Boolean = missingOk, logging: sbt.librarymanagement.UpdateLogging = logging, logicalClock: sbt.librarymanagement.LogicalClock = logicalClock, metadataDirectory: Option[java.io.File] = metadataDirectory, artifactFilter: Option[sbt.librarymanagement.ArtifactTypeFilter] = artifactFilter, offline: Boolean = offline, frozen: Boolean = frozen): UpdateConfiguration = {
+  private def copy(retrieveManaged: Option[sbt.librarymanagement.RetrieveConfiguration] = retrieveManaged, missingOk: Boolean = missingOk, logging: sbt.librarymanagement.UpdateLogging = logging, logicalClock: sbt.librarymanagement.LogicalClock = logicalClock, metadataDirectory: Option[java.io.File] = metadataDirectory, artifactFilter: Option[sbt.librarymanagement.ArtifactTypeFilter] = artifactFilter, offline: Boolean = offline, frozen: Boolean = frozen): UpdateConfiguration = {
     new UpdateConfiguration(retrieveManaged, missingOk, logging, logicalClock, metadataDirectory, artifactFilter, offline, frozen)
   }
   def withRetrieveManaged(retrieveManaged: Option[sbt.librarymanagement.RetrieveConfiguration]): UpdateConfiguration = {

--- a/core/src/main/contraband-scala/sbt/librarymanagement/UpdateConfigurationFormats.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/UpdateConfigurationFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/UpdateLogging.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/UpdateLogging.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/UpdateLoggingFormats.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/UpdateLoggingFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/UpdateReport.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/UpdateReport.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY
@@ -30,7 +30,7 @@ final class UpdateReport private (
   override def toString: String = {
     "Update report:\n\t" + stats + "\n" + configurations.mkString
   }
-  private[this] def copy(cachedDescriptor: java.io.File = cachedDescriptor, configurations: Vector[sbt.librarymanagement.ConfigurationReport] = configurations, stats: sbt.librarymanagement.UpdateStats = stats, stamps: Map[String, Long] = stamps): UpdateReport = {
+  private def copy(cachedDescriptor: java.io.File = cachedDescriptor, configurations: Vector[sbt.librarymanagement.ConfigurationReport] = configurations, stats: sbt.librarymanagement.UpdateStats = stats, stamps: Map[String, Long] = stamps): UpdateReport = {
     new UpdateReport(cachedDescriptor, configurations, stats, stamps)
   }
   def withCachedDescriptor(cachedDescriptor: java.io.File): UpdateReport = {

--- a/core/src/main/contraband-scala/sbt/librarymanagement/UpdateReportFormats.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/UpdateReportFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/UpdateReportLiteFormats.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/UpdateReportLiteFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband-scala/sbt/librarymanagement/UpdateStats.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/UpdateStats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY
@@ -22,7 +22,7 @@ final class UpdateStats private (
   override def toString: String = {
     Seq("Resolve time: " + resolveTime + " ms", "Download time: " + downloadTime + " ms", "Download size: " + downloadSize + " bytes").mkString(", ")
   }
-  private[this] def copy(resolveTime: Long = resolveTime, downloadTime: Long = downloadTime, downloadSize: Long = downloadSize, cached: Boolean = cached): UpdateStats = {
+  private def copy(resolveTime: Long = resolveTime, downloadTime: Long = downloadTime, downloadSize: Long = downloadSize, cached: Boolean = cached): UpdateStats = {
     new UpdateStats(resolveTime, downloadTime, downloadSize, cached)
   }
   def withResolveTime(resolveTime: Long): UpdateStats = {

--- a/core/src/main/contraband-scala/sbt/librarymanagement/UpdateStatsFormats.scala
+++ b/core/src/main/contraband-scala/sbt/librarymanagement/UpdateStatsFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/core/src/main/contraband/librarymanagement2.json
+++ b/core/src/main/contraband/librarymanagement2.json
@@ -126,12 +126,12 @@
       "extra": [
         "def matches(version: sbt.librarymanagement.VersionNumber): Boolean = this.matchesImpl(version)",
         "def expandWildcard: Seq[SemComparator] = {",
-        "  if (op == sbt.internal.librarymanagement.SemSelOperator.Eq && !allFieldsSpecified) {",
+        "  if (op == sbt.internal.librarymanagement.SemSelOperator.Eq && !allFieldsSpecified)",
         "    Seq(",
         "      this.withOp(sbt.internal.librarymanagement.SemSelOperator.Gte),",
         "      this.withOp(sbt.internal.librarymanagement.SemSelOperator.Lte)",
         "    )",
-        "  } else { Seq(this) }",
+        "  else Seq(this)",
         "}"
       ],
       "extraCompanion": [

--- a/ivy/src/main/contraband-scala/sbt/librarymanagement/ivy/ExternalIvyConfiguration.scala
+++ b/ivy/src/main/contraband-scala/sbt/librarymanagement/ivy/ExternalIvyConfiguration.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY
@@ -24,7 +24,7 @@ final class ExternalIvyConfiguration private (
   override def toString: String = {
     "ExternalIvyConfiguration(" + lock + ", " + log + ", " + updateOptions + ", " + baseDirectory + ", " + uri + ", " + extraResolvers + ")"
   }
-  private[this] def copy(lock: Option[xsbti.GlobalLock] = lock, log: Option[xsbti.Logger] = log, updateOptions: sbt.librarymanagement.ivy.UpdateOptions = updateOptions, baseDirectory: Option[java.io.File] = baseDirectory, uri: Option[java.net.URI] = uri, extraResolvers: Vector[sbt.librarymanagement.Resolver] = extraResolvers): ExternalIvyConfiguration = {
+  private def copy(lock: Option[xsbti.GlobalLock] = lock, log: Option[xsbti.Logger] = log, updateOptions: sbt.librarymanagement.ivy.UpdateOptions = updateOptions, baseDirectory: Option[java.io.File] = baseDirectory, uri: Option[java.net.URI] = uri, extraResolvers: Vector[sbt.librarymanagement.Resolver] = extraResolvers): ExternalIvyConfiguration = {
     new ExternalIvyConfiguration(lock, log, updateOptions, baseDirectory, uri, extraResolvers)
   }
   def withLock(lock: Option[xsbti.GlobalLock]): ExternalIvyConfiguration = {

--- a/ivy/src/main/contraband-scala/sbt/librarymanagement/ivy/ExternalIvyConfigurationFormats.scala
+++ b/ivy/src/main/contraband-scala/sbt/librarymanagement/ivy/ExternalIvyConfigurationFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/ivy/src/main/contraband-scala/sbt/librarymanagement/ivy/InlineIvyConfiguration.scala
+++ b/ivy/src/main/contraband-scala/sbt/librarymanagement/ivy/InlineIvyConfiguration.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY
@@ -28,7 +28,7 @@ final class InlineIvyConfiguration private (
   override def toString: String = {
     "InlineIvyConfiguration(" + lock + ", " + log + ", " + updateOptions + ", " + paths + ", " + resolvers + ", " + otherResolvers + ", " + moduleConfigurations + ", " + checksums + ", " + managedChecksums + ", " + resolutionCacheDir + ")"
   }
-  private[this] def copy(lock: Option[xsbti.GlobalLock] = lock, log: Option[xsbti.Logger] = log, updateOptions: sbt.librarymanagement.ivy.UpdateOptions = updateOptions, paths: Option[sbt.librarymanagement.ivy.IvyPaths] = paths, resolvers: Vector[sbt.librarymanagement.Resolver] = resolvers, otherResolvers: Vector[sbt.librarymanagement.Resolver] = otherResolvers, moduleConfigurations: Vector[sbt.librarymanagement.ModuleConfiguration] = moduleConfigurations, checksums: Vector[String] = checksums, managedChecksums: Boolean = managedChecksums, resolutionCacheDir: Option[java.io.File] = resolutionCacheDir): InlineIvyConfiguration = {
+  private def copy(lock: Option[xsbti.GlobalLock] = lock, log: Option[xsbti.Logger] = log, updateOptions: sbt.librarymanagement.ivy.UpdateOptions = updateOptions, paths: Option[sbt.librarymanagement.ivy.IvyPaths] = paths, resolvers: Vector[sbt.librarymanagement.Resolver] = resolvers, otherResolvers: Vector[sbt.librarymanagement.Resolver] = otherResolvers, moduleConfigurations: Vector[sbt.librarymanagement.ModuleConfiguration] = moduleConfigurations, checksums: Vector[String] = checksums, managedChecksums: Boolean = managedChecksums, resolutionCacheDir: Option[java.io.File] = resolutionCacheDir): InlineIvyConfiguration = {
     new InlineIvyConfiguration(lock, log, updateOptions, paths, resolvers, otherResolvers, moduleConfigurations, checksums, managedChecksums, resolutionCacheDir)
   }
   def withLock(lock: Option[xsbti.GlobalLock]): InlineIvyConfiguration = {

--- a/ivy/src/main/contraband-scala/sbt/librarymanagement/ivy/InlineIvyConfigurationFormats.scala
+++ b/ivy/src/main/contraband-scala/sbt/librarymanagement/ivy/InlineIvyConfigurationFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/ivy/src/main/contraband-scala/sbt/librarymanagement/ivy/IvyConfiguration.scala
+++ b/ivy/src/main/contraband-scala/sbt/librarymanagement/ivy/IvyConfiguration.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/ivy/src/main/contraband-scala/sbt/librarymanagement/ivy/IvyConfigurationFormats.scala
+++ b/ivy/src/main/contraband-scala/sbt/librarymanagement/ivy/IvyConfigurationFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/ivy/src/main/contraband-scala/sbt/librarymanagement/ivy/IvyPaths.scala
+++ b/ivy/src/main/contraband-scala/sbt/librarymanagement/ivy/IvyPaths.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY
@@ -20,7 +20,7 @@ final class IvyPaths private (
   override def toString: String = {
     "IvyPaths(" + baseDirectory + ", " + ivyHome + ")"
   }
-  private[this] def copy(baseDirectory: String = baseDirectory, ivyHome: Option[String] = ivyHome): IvyPaths = {
+  private def copy(baseDirectory: String = baseDirectory, ivyHome: Option[String] = ivyHome): IvyPaths = {
     new IvyPaths(baseDirectory, ivyHome)
   }
   def withBaseDirectory(baseDirectory: String): IvyPaths = {

--- a/ivy/src/main/contraband-scala/sbt/librarymanagement/ivy/IvyPathsFormats.scala
+++ b/ivy/src/main/contraband-scala/sbt/librarymanagement/ivy/IvyPathsFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,6 +2,6 @@ addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.0.0")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.8.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
-addSbtPlugin("org.scala-sbt" % "sbt-contraband" % "0.5.3")
+addSbtPlugin("org.scala-sbt" % "sbt-contraband" % "0.6.0")
 
 scalacOptions += "-language:postfixOps"


### PR DESCRIPTION
I noticed sbt-contraband was disabled, but I though it was disabled because there was no version with support for sbt 2.x.
I upgraded to [0.6.0](https://github.com/sbt/contraband/releases/tag/v0.6.0) and reenabled the plugin.

But then it occurred to me, that the sbt version in this project is still 1.9.3 (which is okay), and the reason for disabling it instead was commit b807671ec5b9b7b8379bf3a628ea5b1aac1a603c.

So unsure about the reason why this was disabled before, this PR enables it again