### PR TITLE
Replace scalafmtOnCompile with CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,4 +40,4 @@ jobs:
       if: ${{ matrix.jobtype == 1 }}
       shell: bash
       run: |
-        sbt -v -Dfile.encoding=UTF8 scalafmtCheckAll +test +packagedArtifacts
+        sbt -v -Dfile.encoding=UTF8 +test +packagedArtifacts

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,23 @@
+name: Scalafmt
+
+permissions: {}
+
+on:
+  pull_request:
+    branches: ['**']
+
+jobs:
+  build:
+    name: Code is formatted
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout current branch (full)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Check project is formatted
+        uses: jrouly/scalafmt-native-action@v3
+        with:
+          arguments: '--list'

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = 3.7.4
+version = 3.8.3
 maxColumn = 100
 project.git = true
 project.excludeFilters = [ /sbt-test/, /input_sources/, /contraband-scala/ ]

--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,6 @@ ThisBuild / scmInfo := {
   Some(ScmInfo(url(s"https://github.com/$slug"), s"git@github.com:$slug.git"))
 }
 ThisBuild / licenses := List(("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0")))
-ThisBuild / scalafmtOnCompile := true
 ThisBuild / developers := List(
   Developer("harrah", "Mark Harrah", "@harrah", url("https://github.com/harrah")),
   Developer("eed3si9n", "Eugene Yokota", "@eed3si9n", url("http://eed3si9n.com/")),
@@ -67,8 +66,6 @@ def commonSettings: Seq[Setting[_]] = Def.settings(
   inCompileAndTest(
     (console / scalacOptions) --= Vector("-Ywarn-unused-import", "-Ywarn-unused", "-Xlint")
   ),
-  scalafmtOnCompile := true,
-  Test / scalafmtOnCompile := true,
   Compile / publishArtifact := true,
   Test / publishArtifact := false,
   Test / parallelExecution := false


### PR DESCRIPTION
This PR replaces `scalafmtOnCompile` with a github action that runs scalafmt-native that checks if the entire codebase is formatted. The advantage of this versus using `scalafmtOnCompile` is it doesn't mess up editors while developing and since it is its own github action check it runs in parallel to the main sbt build (this also means it will even run if the sbt fails to load/compile). The scalafmt-native check also only runs on files that are different to `origin/develop` and since its running in native the entire github check typically only takes around 5-10 seconds.

Most critically it ensures that the code is actually properly formatted since with the current setup, its still possible to push unformatted code just by simply forgetting to compile before pushing (which is what happened before).

The only thing that needs to be done after this PR is merged is to add `Scalafmt / Code is formatted` as a github CI status check so that you cannot merge PR's if they are not formatted.