### PR TITLE
Resolvers: clarify `sonatypeCentralSnapshots` is only for snapshots

### DIFF
--- a/core/src/main/scala/sbt/librarymanagement/ResolverExtra.scala
+++ b/core/src/main/scala/sbt/librarymanagement/ResolverExtra.scala
@@ -161,7 +161,7 @@ private[librarymanagement] abstract class ResolverFunctions {
     )
 
   @deprecated(
-    """Sonatype OSS Repository Hosting (OSSRH) will be sunset on 2025-06-30; use the following instead:
+    """Sonatype OSS Repository Hosting (OSSRH) was sunset on 2025-06-30; remove this resolver. If snapshots are required, use:
   resolvers += Resolver.sonatypeCentralSnapshots
 """,
     "1.7.0"
@@ -189,7 +189,7 @@ private[librarymanagement] abstract class ResolverFunctions {
     )
 
   @deprecated(
-    """Sonatype OSS Repository Hosting (OSSRH) will be sunset on 2025-06-30; use the following instead:
+    """Sonatype OSS Repository Hosting (OSSRH) was sunset on 2025-06-30; remove this resolver. If snapshots are required, use:
   resolvers += Resolver.sonatypeCentralSnapshots""",
     "1.11.2"
   )


### PR DESCRIPTION
The current deprecation messages for `sonatypeRepo()` & `sonatypeOssRepos()` (added with https://github.com/sbt/librarymanagement/pull/517) say:

> use the following instead: resolvers += Resolver.sonatypeCentral**Snapshots**

...but following this advice can expose projects to using **snapshot** artifacts when they did not previously! This is unfortunate as snapshots artifacts are inherently more risky, as they are mutable.


For example, invocations of `sonatypeOssRepos()` like [this](https://github.com/guardian/frontend/blob/76234e013f550ac600fbf0bb924c19a1a6165295/project/plugins.sbt#L10):

<img width="1253" height="110" alt="image" src="https://github.com/user-attachments/assets/d39f13bb-091d-4706-aa14-c3696fac9baa" />

```scala
resolvers ++= Resolver.sonatypeOssRepos("releases")
```

...should _not_ be replaced by `sonatypeCentralSnapshots()`, as, AFAIK, only non-snapshot releases would be in the `sonatypeOssRepos("releases")` repository.

In an ideal world (where snapshots are not, and were not, being used!) the `sonatypeOssRepos()` entry should just be [removed](https://github.com/guardian/frontend/pull/28084) (as I don't _think_ there is any useful equivalent now that we're using Central Portal? In the old days we could get our artifacts a little quicker with `sonatypeOssRepos()`).

Only if snapshots are in use, users should replace the entry with `sonatypeCentralSnapshots()`.
