### PR TITLE
chore: add scala nightly repository resolver

### DIFF
--- a/core/src/main/scala/sbt/librarymanagement/ResolverExtra.scala
+++ b/core/src/main/scala/sbt/librarymanagement/ResolverExtra.scala
@@ -110,6 +110,7 @@ private[librarymanagement] abstract class ResolverFunctions {
   val SonatypeReleasesRepository =
     "https://oss.sonatype.org/service/local/repositories/releases/content/"
   val SonatypeCentralRepository = "https://central.sonatype.com/repository"
+  val ScalaNightlyRepository = "https://repo.scala-lang.org/artifactory/maven-nightlies/"
   val JavaNet2RepositoryName = "java.net Maven2 Repository"
   val JavaNet2RepositoryRoot = javanet2RepositoryRoot(useSecureResolvers)
   val JCenterRepositoryName = "jcenter"
@@ -122,6 +123,8 @@ private[librarymanagement] abstract class ResolverFunctions {
 
   def mavenCentral: Resolver = DefaultMavenRepository
   def defaults: Vector[Resolver] = Vector(mavenCentral)
+  def scalaNightlyRepository: Resolver =
+    MavenRepository("The Scala Nightly Repository", ScalaNightlyRepository)
 
   // TODO: This switch is only kept for backward compatibility. Hardcode to HTTPS in the future.
   private[sbt] def centralRepositoryRoot(secure: Boolean) =


### PR DESCRIPTION
Scala 3 Nightlies are now published to https://repo.scala-lang.org.
In this PR, we add a resolver to make it easier for people to add the repository to their build.\

/cc @eed3si9n (It would be nice if this is also included in sbt 1.11.5)