### PR TITLE
Add ability to filter configurations

### DIFF
--- a/core/src/main/scala/sbt/librarymanagement/UpdateReportExtra.scala
+++ b/core/src/main/scala/sbt/librarymanagement/UpdateReportExtra.scala
@@ -142,18 +142,25 @@ private[librarymanagement] abstract class UpdateReportExtra {
     }
   }
 
-  def allModuleReports: Vector[ModuleReport] = {
-    configurations.flatMap(_.modules).groupBy(mR => moduleKey(mR.module)).toVector map {
-      case (_, v) =>
-        v reduceLeft { (agg, x) =>
-          agg.withConfigurations(
-            (agg.configurations, x.configurations) match {
-              case (v, _) if v.isEmpty  => x.configurations
-              case (ac, v) if v.isEmpty => ac
-              case (ac, xc)             => ac ++ xc
-            }
-          )
-        }
+  def allModuleReports: Vector[ModuleReport] = allModuleReports(_ => true)
+
+  def allModuleReports(
+      filterConfiguration: ConfigurationReport => Boolean
+  ): Vector[ModuleReport] = {
+    configurations
+      .filter(filterConfiguration)
+      .flatMap(_.modules)
+      .groupBy(mR => moduleKey(mR.module))
+      .toVector map { case (_, v) =>
+      v reduceLeft { (agg, x) =>
+        agg.withConfigurations(
+          (agg.configurations, x.configurations) match {
+            case (v, _) if v.isEmpty  => x.configurations
+            case (ac, v) if v.isEmpty => ac
+            case (ac, xc)             => ac ++ xc
+          }
+        )
+      }
     }
   }
 


### PR DESCRIPTION
In https://github.com/sbt/librarymanagement/pull/428 I added `allModuleReports` with the intention of it being used in sbt-license-report however we still couldn't end up using it because it doesn't have the ability to filter out configurations.

This PR adds an overloaded version of `allModuleReports` that allows you to filter by configuration (see https://github.com/sbt/sbt-license-report/pull/141 for more info)