### PR TITLE
[1.x] bport: Add Test configuration to evictionWarningOptions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ val _ = {
   // https://github.com/sbt/contraband/issues/122
   sys.props += ("line.separator" -> "\n")
 }
-Global / semanticdbEnabled := !(Global / insideCI).value
+Global / semanticdbEnabled := false
 Global / semanticdbVersion := "4.9.9"
 ThisBuild / version := {
   val old = (ThisBuild / version).value

--- a/core/src/main/scala/sbt/internal/librarymanagement/VersionRange.scala
+++ b/core/src/main/scala/sbt/internal/librarymanagement/VersionRange.scala
@@ -2,15 +2,155 @@ package sbt
 package internal
 package librarymanagement
 
+import sbt.librarymanagement.VersionNumber
+
 object VersionRange {
 
   /** True if the revision is an ivy-range, not a complete revision. */
   def isVersionRange(revision: String): Boolean = {
-    (revision endsWith "+") ||
-    (revision contains "[") ||
-    (revision contains "]") ||
-    (revision contains "(") ||
-    (revision contains ")")
+    (revision.endsWith("+")) ||
+    (revision.contains("[")) ||
+    (revision.contains("]")) ||
+    (revision.contains("(")) ||
+    (revision.contains(")")) ||
+    // Comma-separated range e.g. "1.3.1,2.3" (fixes #6244 when Coursier passes range without brackets)
+    (revision.contains(",") && revision.exists(_.isDigit))
+  }
+
+  /**
+   * Checks if a version satisfies a version range.
+   * @param version The version to check (e.g., "4.2.1")
+   * @param range The version range (e.g., "[4.1.0,5)" or "[1.0,2.0]")
+   * @return true if version is within the range, false otherwise
+   */
+  def versionSatisfiesRange(version: String, range: String): Boolean = {
+    if (!isVersionRange(range)) {
+      // Not a range, just compare directly
+      version == range
+    } else if (range.contains(",") && !hasMavenVersionRange(range)) {
+      // Comma-separated range without brackets e.g. "1.3.1,2.3" (fixes #6244)
+      val parts = range.split(",", 2)
+      if (parts.length == 2) {
+        val lower = parts(0).trim
+        val upper = parts(1).trim
+        lower.nonEmpty && upper.nonEmpty &&
+        compareVersions(version, lower) >= 0 && compareVersions(version, upper) <= 0
+      } else false
+    } else if (range.endsWith("+")) {
+      // Handle plus ranges like "1.0+" meaning >= 1.0
+      val base = range.dropRight(1)
+      compareVersions(version, base) >= 0
+    } else if (hasMavenVersionRange(range)) {
+      // Parse Maven-style range like [1.0,2.0) or (1.0,2.0]
+      parseMavenRange(range) match {
+        case Some((lowerBound, lowerInclusive, upperBound, upperInclusive)) =>
+          val lowerOk = lowerBound match {
+            case Some(lb) =>
+              val cmp = compareVersions(version, lb)
+              if (lowerInclusive) cmp >= 0 else cmp > 0
+            case None => true
+          }
+          val upperOk = upperBound match {
+            case Some(ub) =>
+              val cmp = compareVersions(version, ub)
+              if (upperInclusive) cmp <= 0 else cmp < 0
+            case None => true
+          }
+          lowerOk && upperOk
+        case None => false
+      }
+    } else {
+      false
+    }
+  }
+
+  /**
+   * Parses a Maven-style version range.
+   * @return Some((lowerBound, lowerInclusive, upperBound, upperInclusive)) or None
+   */
+  private def parseMavenRange(
+      range: String
+  ): Option[(Option[String], Boolean, Option[String], Boolean)] = {
+    val trimmed = range.trim
+    if (trimmed.length < 2) None
+    else {
+      val startChar = trimmed.head
+      val endChar = trimmed.last
+
+      val lowerInclusive = startChar == '['
+      val upperInclusive = endChar == ']'
+
+      if (!Set('[', '(').contains(startChar) || !Set(']', ')').contains(endChar)) {
+        None
+      } else {
+        val inner = trimmed.substring(1, trimmed.length - 1)
+        val commaIdx = inner.indexOf(',')
+
+        if (commaIdx < 0) {
+          // Single version constraint like [1.0] means exactly 1.0
+          val v = inner.trim
+          if (v.nonEmpty) Some((Some(v), true, Some(v), true))
+          else None
+        } else {
+          val lower = inner.substring(0, commaIdx).trim
+          val upper = inner.substring(commaIdx + 1).trim
+          Some(
+            (
+              if (lower.nonEmpty) Some(lower) else None,
+              lowerInclusive,
+              if (upper.nonEmpty) Some(upper) else None,
+              upperInclusive
+            )
+          )
+        }
+      }
+    }
+  }
+
+  /**
+   * Compares two version strings.
+   * @return negative if v1 < v2, 0 if v1 == v2, positive if v1 > v2
+   */
+  private def compareVersions(v1: String, v2: String): Int = {
+    val vn1 = VersionNumber(v1)
+    val vn2 = VersionNumber(v2)
+
+    // Compare numeric parts first
+    val nums1 = vn1.numbers
+    val nums2 = vn2.numbers
+    val maxLen = math.max(nums1.length, nums2.length)
+
+    val numericComparison = (0 until maxLen).iterator
+      .map { i =>
+        val n1 = if (i < nums1.length) nums1(i) else 0L
+        val n2 = if (i < nums2.length) nums2(i) else 0L
+        n1.compare(n2)
+      }
+      .find(_ != 0)
+
+    numericComparison match {
+      case Some(cmp) => cmp
+      case None      =>
+        // If numeric parts are equal, compare tags (versions with tags are usually pre-releases)
+        val tags1 = vn1.tags
+        val tags2 = vn2.tags
+
+        // No tags means release version, which is higher than any pre-release
+        if (tags1.isEmpty && tags2.nonEmpty) 1
+        else if (tags1.nonEmpty && tags2.isEmpty) -1
+        else {
+          // Compare tags lexicographically
+          val tagMaxLen = math.max(tags1.length, tags2.length)
+          val tagComparison = (0 until tagMaxLen).iterator
+            .map { i =>
+              val t1 = if (i < tags1.length) tags1(i) else ""
+              val t2 = if (i < tags2.length) tags2(i) else ""
+              t1.compare(t2)
+            }
+            .find(_ != 0)
+          tagComparison.getOrElse(0)
+        }
+    }
   }
 
   // Assuming Ivy is used to resolve conflict, this removes the version range
@@ -54,11 +194,11 @@ object VersionRange {
         case "+"                  => "[0,)"
         case DotPlusPattern(base) => plusRange(base)
         // This is a heuristic.  Maven just doesn't support Ivy's notions of 1+, so
-        // we assume version ranges never go beyond 5 siginificant digits.
+        // we assume version ranges never go beyond 5 significant digits.
         case NumPlusPattern(tail) => (0 until maxDigit).map(plusRange(tail, _)).mkString(",")
         case DotNumPlusPattern(base, tail) =>
           (0 until maxDigit).map(plusRange(base + "." + tail, _)).mkString(",")
-        case rev if rev endsWith "+" =>
+        case rev if rev.endsWith("+") =>
           sys.error(s"dynamic revision '$rev' cannot be translated to POM")
         case rev if startSym(rev(0)) && stopSym(rev(rev.length - 1)) =>
           val start = rev(0)
@@ -80,8 +220,8 @@ object VersionRange {
     if (version.length <= 1) false
     else startSym(version(0)) && stopSym(version(version.length - 1))
 
-  private[this] val startSym = Set(']', '[', '(')
-  private[this] val stopSym = Set(']', '[', ')')
-  private[this] val MavenVersionSetPattern =
+  private val startSym = Set(']', '[', '(')
+  private val stopSym = Set(']', '[', ')')
+  private val MavenVersionSetPattern =
     """([\]\[\(])([\w\.\-]+)?(,)?([\w\.\-]+)?([\]\[\)])(,.+)?""".r
 }

--- a/core/src/main/scala/sbt/librarymanagement/EvictionError.scala
+++ b/core/src/main/scala/sbt/librarymanagement/EvictionError.scala
@@ -23,11 +23,30 @@ object EvictionError {
       assumedVersionSchemeJava: String,
       assumedEvictionErrorLevel: Level.Value,
   ): EvictionError = {
-    val options = EvictionWarningOptions.full
-    val evictions = EvictionWarning.buildEvictions(options, report)
+    apply(
+      report,
+      module,
+      schemes,
+      assumedVersionScheme,
+      assumedVersionSchemeJava,
+      assumedEvictionErrorLevel,
+      EvictionWarningOptions.default.configurations,
+    )
+  }
+
+  def apply(
+      report: UpdateReport,
+      module: ModuleDescriptor,
+      schemes: Seq[ModuleID],
+      assumedVersionScheme: String,
+      assumedVersionSchemeJava: String,
+      assumedEvictionErrorLevel: Level.Value,
+      configurations: Seq[ConfigRef],
+  ): EvictionError = {
+    val evictions = EvictionWarning
+      .buildEvictions(configurations, report)
     processEvictions(
       module,
-      options,
       evictions,
       schemes,
       assumedVersionScheme,
@@ -38,101 +57,122 @@ object EvictionError {
 
   private[sbt] def processEvictions(
       module: ModuleDescriptor,
-      options: EvictionWarningOptions,
-      reports: Seq[OrganizationArtifactReport],
+      reports: Seq[(ConfigRef, OrganizationArtifactReport)],
       schemes: Seq[ModuleID],
       assumedVersionScheme: String,
       assumedVersionSchemeJava: String,
       assumedEvictionErrorLevel: Level.Value,
   ): EvictionError = {
     val directDependencies = module.directDependencies
-    val pairs = reports map { detail =>
-      val evicteds = detail.modules filter { _.evicted }
-      val winner = (detail.modules filterNot { _.evicted }).headOption
-      new EvictionPair(
-        detail.organization,
-        detail.name,
-        winner,
-        evicteds,
-        true,
-        options.showCallers
-      )
-    }
-    val incompatibleEvictions: mutable.ListBuffer[(EvictionPair, String)] = mutable.ListBuffer()
-    val assumedIncompatEvictions: mutable.ListBuffer[(EvictionPair, String)] = mutable.ListBuffer()
     val sbvOpt = module.scalaModuleInfo.map(_.scalaBinaryVersion)
     val userDefinedSchemes: Map[(String, String), String] = Map(schemes flatMap { s =>
       val organization = s.organization
       VersionSchemes.validateScheme(s.revision)
       val versionScheme = s.revision
       (s.crossVersion, sbvOpt) match {
-        case (_: Binary, Some("2.13")) =>
+        case (b: Binary, Some("2.13")) =>
           List(
-            (s.organization, s"${s.name}_2.13") -> versionScheme,
-            (s.organization, s"${s.name}_3") -> versionScheme
+            (s.organization, s"${s.name}${b.suffix}_2.13") -> versionScheme,
+            (s.organization, s"${s.name}${b.suffix}_3") -> versionScheme
           )
-        case (_: Binary, Some(sbv)) if sbv.startsWith("3.0") || sbv == "3" =>
+        case (b: Binary, Some(sbv)) if sbv.startsWith("3.0") || sbv == "3" =>
           List(
-            (s.organization, s"${s.name}_$sbv") -> versionScheme,
-            (s.organization, s"${s.name}_2.13") -> versionScheme
+            (s.organization, s"${s.name}${b.suffix}_$sbv") -> versionScheme,
+            (s.organization, s"${s.name}${b.suffix}_2.13") -> versionScheme
           )
-        case (_: Binary, Some(sbv)) =>
-          List((s.organization, s"${s.name}_$sbv") -> versionScheme)
+        case (b: Binary, Some(sbv)) =>
+          List((s.organization, s"${s.name}${b.suffix}_$sbv") -> versionScheme)
         case _ =>
           List((s.organization, s.name) -> versionScheme)
       }
     }: _*)
+    val pairs = reports
+      .flatMap { case (config, detail) =>
+        val evicteds = detail.modules filter { _.evicted }
+        val winner = (detail.modules filterNot { _.evicted }).headOption
+        // don't report on a transitive eviction that does not have a winner
+        // https://github.com/sbt/sbt/issues/4946
+        winner match {
+          case Some(winner) =>
+            // from libraryDependencyScheme or defined in the pom using the `info.versionScheme` attribute
+            val userDefinedSchemeOrFromPom = {
+              def fromLibraryDependencySchemes(org: String = "*", mod: String = "*") =
+                userDefinedSchemes.get((org, mod))
+              def fromWinnerPom = VersionSchemes.extractFromExtraAttributes(
+                winner.extraAttributes.toMap ++ winner.module.extraAttributes
+              )
 
-    pairs foreach {
-      // don't report on a transitive eviction that does not have a winner
-      // https://github.com/sbt/sbt/issues/4946
-      case p if p.winner.isDefined =>
-        val winner = p.winner.get
-
-        def hasIncompatibleVersionForScheme(scheme: String) = {
-          val isCompat = VersionSchemes.evalFunc(scheme)
-          p.evicteds.exists { r =>
-            !isCompat((r.module, Some(winner.module), module.scalaModuleInfo))
-          }
-        }
-
-        // from libraryDependencyScheme or defined in the pom using the `info.versionScheme` attribute
-        val userDefinedSchemeOrFromPom = {
-          def fromLibraryDependencySchemes(org: String = "*", mod: String = "*") =
-            userDefinedSchemes.get((org, mod))
-          def fromWinnerPom = VersionSchemes.extractFromExtraAttributes(
-            winner.extraAttributes.toMap ++ winner.module.extraAttributes
-          )
-
-          fromLibraryDependencySchemes(p.organization, p.name) // by org and name
-            .orElse(fromLibraryDependencySchemes(p.organization)) // for whole org
-            .orElse(fromWinnerPom) // from pom
-            .orElse(fromLibraryDependencySchemes()) // global
-        }
-
-        // We want the user to be able to suppress eviction errors for a specific library,
-        // which would result in an incompatible eviction based on the assumed version scheme.
-        // So, only fall back to the assumed scheme if there is no given scheme by the user or the pom.
-        userDefinedSchemeOrFromPom match {
-          case Some(givenScheme) =>
-            if (hasIncompatibleVersionForScheme(givenScheme))
-              incompatibleEvictions += (p -> givenScheme)
-          case None =>
+              fromLibraryDependencySchemes(detail.organization, detail.name) // by org and name
+                .orElse(fromLibraryDependencySchemes(detail.organization)) // for whole org
+                .orElse(fromWinnerPom) // from pom
+                .orElse(fromLibraryDependencySchemes()) // global
+            }
             val assumedScheme =
-              if (isNameScalaSuffixed(p.name)) assumedVersionScheme
+              if (isNameScalaSuffixed(detail.name)) assumedVersionScheme
               else assumedVersionSchemeJava
 
-            if (hasIncompatibleVersionForScheme(assumedScheme))
-              assumedIncompatEvictions += (p -> assumedScheme)
-        }
+            // We want the user to be able to suppress eviction errors for a specific library,
+            // which would result in an incompatible eviction based on the assumed version scheme.
+            // So, only fall back to the assumed scheme if there is no given scheme by the user or the pom.
+            val (scheme, isAssumed) = userDefinedSchemeOrFromPom
+              .map(scheme => (scheme, false))
+              .getOrElse((assumedScheme, true))
 
-      case _ => ()
-    }
+            val hasIncompatibleVersionForScheme = {
+              val isCompat = VersionSchemes.evalFunc(scheme)
+              evicteds.exists { r =>
+                !isCompat((r.module, Some(winner.module), module.scalaModuleInfo))
+              }
+            }
+
+            if (hasIncompatibleVersionForScheme)
+              Some(
+                (
+                  EvictionErrorPair(
+                    detail.name,
+                    detail.organization,
+                    winner.module,
+                    evicteds.map(_.module),
+                    callers(winner, evicteds),
+                    scheme,
+                    configurations = Vector.empty,
+                    isAssumed,
+                  ),
+                  config
+                )
+              )
+            else None
+          case None => None
+        }
+      }
+      .groupBy(_._1)
+      .map { case (pair, configs) =>
+        pair.copy(configurations = configs.map(_._2).toVector)
+      }
+
+    val (assumedIncompatibleEvictions, incompatibleEvictions) = pairs.partition(_.isAssumed)
 
     new EvictionError(
       incompatibleEvictions.toList,
-      assumedIncompatEvictions.toList,
+      assumedIncompatibleEvictions.toList,
     )
+  }
+
+  private def callers(
+      winner: ModuleReport,
+      evicteds: Vector[ModuleReport],
+  ): List[(ModuleID, String)] = {
+    val seen: mutable.Set[ModuleID] = mutable.Set()
+    (evicteds.toList :+ winner).flatMap { r =>
+      val rev = r.module.revision
+      r.callers.toList flatMap { caller =>
+        if (seen(caller.caller)) Nil
+        else {
+          seen += caller.caller
+          List((caller.caller, rev))
+        }
+      }
+    }
   }
 
   implicit val evictionErrorLines: ShowLines[EvictionError] = ShowLines { (a: EvictionError) =>
@@ -140,9 +180,20 @@ object EvictionError {
   }
 }
 
+private[sbt] final case class EvictionErrorPair(
+    name: String,
+    organization: String,
+    winner: ModuleID,
+    evicted: Vector[ModuleID],
+    callers: List[(ModuleID, String)],
+    scheme: String,
+    configurations: Vector[ConfigRef],
+    isAssumed: Boolean
+)
+
 final class EvictionError private[sbt] (
-    val incompatibleEvictions: Seq[(EvictionPair, String)],
-    val assumedIncompatibleEvictions: Seq[(EvictionPair, String)],
+    private[sbt] val incompatibleEvictions: Seq[EvictionErrorPair],
+    private[sbt] val assumedIncompatibleEvictions: Seq[EvictionErrorPair],
 ) {
   def run(): Unit =
     if (incompatibleEvictions.nonEmpty) {
@@ -153,29 +204,30 @@ final class EvictionError private[sbt] (
 
   def toAssumedLines: List[String] = toLines(assumedIncompatibleEvictions, true)
 
-  def toLines(evictions: Seq[(EvictionPair, String)], assumed: Boolean): List[String] = {
+  def toLines(
+      evictions: Seq[EvictionErrorPair],
+      assumed: Boolean
+  ): List[String] = {
     val out: mutable.ListBuffer[String] = mutable.ListBuffer()
     out += "found version conflict(s) in library dependencies; some are suspected to be binary incompatible:"
     out += ""
-    evictions.foreach({ case (a, scheme) =>
-      val seen: mutable.Set[ModuleID] = mutable.Set()
-      val callers: List[String] = (a.evicteds.toList ::: a.winner.toList) flatMap { r =>
-        val rev = r.module.revision
-        r.callers.toList flatMap { caller =>
-          if (seen(caller.caller)) Nil
-          else {
-            seen += caller.caller
-            List(f"\t    +- ${caller}%-50s (depends on $rev)")
-          }
-        }
+    evictions.foreach({ case a =>
+      val callers: List[String] = a.callers.map { case (caller, rev) =>
+        f"\t    +- ${caller}%-50s (depends on $rev)"
       }
       val que = if (assumed) "?" else ""
-      val winnerRev = a.winner match {
-        case Some(r) => s":${r.module.revision} ($scheme$que) is selected over ${a.evictedRevs}"
-        case _       => " is evicted for all versions"
-      }
-      val title = s"\t* ${a.organization}:${a.name}$winnerRev"
-      val lines = title :: (if (a.showCallers) callers.reverse else Nil) ::: List("")
+      val evictedRevs = a.evicted.map(_.revision)
+      val evictedRevsTitle =
+        if (evictedRevs.size <= 1) evictedRevs.mkString
+        else evictedRevs.mkString("{", ", ", "}")
+
+      val winnerRev =
+        s":${a.winner.revision} (${a.scheme}$que) is selected over ${evictedRevsTitle}"
+      val configurationTitle =
+        if (a.configurations.size <= 1) a.configurations.mkString
+        else a.configurations.mkString("{", ", ", "}")
+      val title = s"\t* ${a.organization}:${a.name}$winnerRev for $configurationTitle"
+      val lines = title :: callers.reverse ::: List("")
       out ++= lines
     })
     out.toList

--- a/core/src/main/scala/sbt/librarymanagement/EvictionError.scala
+++ b/core/src/main/scala/sbt/librarymanagement/EvictionError.scala
@@ -211,25 +211,27 @@ final class EvictionError private[sbt] (
     val out: mutable.ListBuffer[String] = mutable.ListBuffer()
     out += "found version conflict(s) in library dependencies; some are suspected to be binary incompatible:"
     out += ""
-    evictions.foreach({ case a =>
-      val callers: List[String] = a.callers.map { case (caller, rev) =>
-        f"\t    +- ${caller}%-50s (depends on $rev)"
-      }
-      val que = if (assumed) "?" else ""
-      val evictedRevs = a.evicted.map(_.revision)
-      val evictedRevsTitle =
-        if (evictedRevs.size <= 1) evictedRevs.mkString
-        else evictedRevs.mkString("{", ", ", "}")
+    evictions
+      .sortBy(_.configurations.mkString)
+      .foreach({ case a =>
+        val callers: List[String] = a.callers.map { case (caller, rev) =>
+          f"\t    +- ${caller}%-50s (depends on $rev)"
+        }
+        val que = if (assumed) "?" else ""
+        val evictedRevs = a.evicted.map(_.revision)
+        val evictedRevsTitle =
+          if (evictedRevs.size <= 1) evictedRevs.mkString
+          else evictedRevs.mkString("{", ", ", "}")
 
-      val winnerRev =
-        s":${a.winner.revision} (${a.scheme}$que) is selected over ${evictedRevsTitle}"
-      val configurationTitle =
-        if (a.configurations.size <= 1) a.configurations.mkString
-        else a.configurations.mkString("{", ", ", "}")
-      val title = s"\t* ${a.organization}:${a.name}$winnerRev for $configurationTitle"
-      val lines = title :: callers.reverse ::: List("")
-      out ++= lines
-    })
+        val winnerRev =
+          s":${a.winner.revision} (${a.scheme}$que) is selected over ${evictedRevsTitle}"
+        val configurationTitle =
+          if (a.configurations.size <= 1) a.configurations.mkString
+          else a.configurations.mkString("{", ", ", "}")
+        val title = s"\t* ${a.organization}:${a.name}$winnerRev for $configurationTitle"
+        val lines = title :: callers.reverse ::: List("")
+        out ++= lines
+      })
     out.toList
   }
 }

--- a/core/src/main/scala/sbt/librarymanagement/EvictionWarning.scala
+++ b/core/src/main/scala/sbt/librarymanagement/EvictionWarning.scala
@@ -2,8 +2,9 @@ package sbt.librarymanagement
 
 import collection.mutable
 import Configurations.Compile
+import Configurations.Test
 import ScalaArtifacts.{ LibraryID, CompilerID }
-import sbt.internal.librarymanagement.VersionSchemes
+import sbt.internal.librarymanagement.{ VersionSchemes, VersionRange }
 import sbt.util.Logger
 import sbt.util.ShowLines
 
@@ -74,7 +75,7 @@ object EvictionWarningOptions {
   def default: EvictionWarningOptions = summary
   def full: EvictionWarningOptions =
     new EvictionWarningOptions(
-      Vector(Compile),
+      Vector(Compile, Test),
       warnScalaVersionEviction = true,
       warnDirectEvictions = true,
       warnTransitiveEvictions = true,
@@ -85,7 +86,7 @@ object EvictionWarningOptions {
     )
   def summary: EvictionWarningOptions =
     new EvictionWarningOptions(
-      Vector(Compile),
+      Vector(Compile, Test),
       warnScalaVersionEviction = false,
       warnDirectEvictions = false,
       warnTransitiveEvictions = false,
@@ -268,31 +269,20 @@ object EvictionWarning {
       options: EvictionWarningOptions,
       report: UpdateReport
   ): EvictionWarning = {
-    val evictions = buildEvictions(options, report)
+    val evictions = buildEvictions(options.configurations, report)
     processEvictions(module, options, evictions)
   }
 
   private[sbt] def buildEvictions(
-      options: EvictionWarningOptions,
+      configurations: Seq[ConfigRef],
       report: UpdateReport
-  ): Seq[OrganizationArtifactReport] = {
-    val buffer: mutable.ListBuffer[OrganizationArtifactReport] = mutable.ListBuffer()
+  ): Seq[(ConfigRef, OrganizationArtifactReport)] = {
     val confs = report.configurations filter { x =>
-      options.configurations.contains[ConfigRef](x.configuration)
+      configurations.contains[ConfigRef](x.configuration)
     }
-    confs flatMap { confReport =>
-      confReport.details map { detail =>
-        if (
-          (detail.modules exists { _.evicted }) &&
-          !(buffer exists { x =>
-            (x.organization == detail.organization) && (x.name == detail.name)
-          })
-        ) {
-          buffer += detail
-        }
-      }
-    }
-    buffer.toList.toVector
+    confs.flatMap { confReport =>
+      confReport.details.map(report => (confReport.configuration, report))
+    }.toVector
   }
 
   private[sbt] def isScalaArtifact(
@@ -310,9 +300,21 @@ object EvictionWarning {
   private[sbt] def processEvictions(
       module: ModuleDescriptor,
       options: EvictionWarningOptions,
-      reports: Seq[OrganizationArtifactReport]
+      configsAndReports: Seq[(ConfigRef, OrganizationArtifactReport)]
   ): EvictionWarning = {
     val directDependencies = module.directDependencies
+    val buffer: mutable.ListBuffer[OrganizationArtifactReport] = mutable.ListBuffer()
+    configsAndReports.foreach { case (_, detail) =>
+      if (
+        (detail.modules exists { _.evicted }) &&
+        !(buffer exists { x =>
+          (x.organization == detail.organization) && (x.name == detail.name)
+        })
+      ) {
+        buffer += detail
+      }
+    }
+    val reports = buffer.toList.toVector
     val pairs = reports map { detail =>
       val evicteds = detail.modules filter { _.evicted }
       val winner = (detail.modules filterNot { _.evicted }).headOption
@@ -337,28 +339,43 @@ object EvictionWarning {
     def guessCompatible(p: EvictionPair): Boolean =
       p.evicteds forall { r =>
         val winnerOpt = p.winner map { _.module }
-        val extraAttributes = ((p.winner match {
-          case Some(r) => r.extraAttributes
-          case _       => Map.empty
-        }): collection.immutable.Map[String, String]) ++ (winnerOpt match {
-          case Some(w) => w.extraAttributes
-          case _       => Map.empty
-        })
-        val schemeOpt = VersionSchemes.extractFromExtraAttributes(extraAttributes)
-        val f = (winnerOpt, schemeOpt) match {
-          case (Some(_), Some(VersionSchemes.Always)) =>
-            EvictionWarningOptions.guessTrue
-          case (Some(_), Some(VersionSchemes.Strict)) =>
-            EvictionWarningOptions.guessStrict
-          case (Some(_), Some(VersionSchemes.EarlySemVer)) =>
-            EvictionWarningOptions.guessEarlySemVer
-          case (Some(_), Some(VersionSchemes.SemVerSpec)) =>
-            EvictionWarningOptions.guessSemVer
-          case (Some(_), Some(VersionSchemes.PackVer)) =>
-            EvictionWarningOptions.evalPvp
-          case _ => options.guessCompatible(_)
+        val evictedRev = r.module.revision
+        // Same version: no eviction (fixes #6244 when resolution picks version within requested range)
+        val sameVersion: Boolean = winnerOpt.exists(_.revision == evictedRev)
+        // Check if the evicted module's revision is a version range and if the winner satisfies it
+        // This handles cases like [4.1.0,5) where 4.2.1 would be within range (fixes #3978)
+        // and [1.3.1,2.3] where 2.3 is valid (fixes #6244)
+        val winnerSatisfiesRange: Boolean = winnerOpt match {
+          case Some(winner) if VersionRange.isVersionRange(evictedRev) =>
+            VersionRange.versionSatisfiesRange(winner.revision, evictedRev)
+          case _ => false
         }
-        f((r.module, winnerOpt, module.scalaModuleInfo))
+        if (sameVersion || winnerSatisfiesRange) {
+          true
+        } else {
+          val extraAttributes = ((p.winner match {
+            case Some(r) => r.extraAttributes
+            case _       => Map.empty
+          }): collection.immutable.Map[String, String]) ++ (winnerOpt match {
+            case Some(w) => w.extraAttributes
+            case _       => Map.empty
+          })
+          val schemeOpt = VersionSchemes.extractFromExtraAttributes(extraAttributes)
+          val f = (winnerOpt, schemeOpt) match {
+            case (Some(_), Some(VersionSchemes.Always)) =>
+              EvictionWarningOptions.guessTrue
+            case (Some(_), Some(VersionSchemes.Strict)) =>
+              EvictionWarningOptions.guessStrict
+            case (Some(_), Some(VersionSchemes.EarlySemVer)) =>
+              EvictionWarningOptions.guessEarlySemVer
+            case (Some(_), Some(VersionSchemes.SemVerSpec)) =>
+              EvictionWarningOptions.guessSemVer
+            case (Some(_), Some(VersionSchemes.PackVer)) =>
+              EvictionWarningOptions.evalPvp
+            case _ => options.guessCompatible(_)
+          }
+          f((r.module, winnerOpt, module.scalaModuleInfo))
+        }
       }
     pairs foreach {
       case p if isScalaArtifact(module, p.organization, p.name) =>
@@ -397,28 +414,29 @@ object EvictionWarning {
     )
   }
 
-  implicit val evictionWarningLines: ShowLines[EvictionWarning] = ShowLines { a: EvictionWarning =>
-    import ShowLines._
-    val out: mutable.ListBuffer[String] = mutable.ListBuffer()
-    if (a.options.warnEvictionSummary && a.binaryIncompatibleEvictionExists) {
-      out += "There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings."
-    }
+  implicit val evictionWarningLines: ShowLines[EvictionWarning] = ShowLines {
+    (a: EvictionWarning) =>
+      import ShowLines._
+      val out: mutable.ListBuffer[String] = mutable.ListBuffer()
+      if (a.options.warnEvictionSummary && a.binaryIncompatibleEvictionExists) {
+        out += "There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings."
+      }
 
-    if (a.scalaEvictions.nonEmpty) {
-      out += "Scala version was updated by one of library dependencies:"
-      out ++= (a.scalaEvictions flatMap { _.lines })
-      out += "To force scalaVersion, add the following:"
-      out += "\tscalaModuleInfo ~= (_.map(_.withOverrideScalaVersion(true)))"
-    }
+      if (a.scalaEvictions.nonEmpty) {
+        out += "Scala version was updated by one of library dependencies:"
+        out ++= (a.scalaEvictions flatMap { _.lines })
+        out += "To force scalaVersion, add the following:"
+        out += "\tscalaModuleInfo ~= (_.map(_.withOverrideScalaVersion(true)))"
+      }
 
-    if (a.directEvictions.nonEmpty || a.transitiveEvictions.nonEmpty) {
-      out += "Found version conflict(s) in library dependencies; some are suspected to be binary incompatible:"
-      out += ""
-      out ++= (a.directEvictions flatMap { _.lines })
-      out ++= (a.transitiveEvictions flatMap { _.lines })
-    }
+      if (a.directEvictions.nonEmpty || a.transitiveEvictions.nonEmpty) {
+        out += "Found version conflict(s) in library dependencies; some are suspected to be binary incompatible:"
+        out += ""
+        out ++= (a.directEvictions flatMap { _.lines })
+        out ++= (a.transitiveEvictions flatMap { _.lines })
+      }
 
-    out.toList
+      out.toList
   }
 
   private[sbt] def infoAllTheThings(a: EvictionWarning): List[String] =

--- a/ivy/src/test/scala/sbt/internal/librarymanagement/EvictionErrorSpec.scala
+++ b/ivy/src/test/scala/sbt/internal/librarymanagement/EvictionErrorSpec.scala
@@ -26,10 +26,11 @@ object EvictionErrorSpec extends BaseIvySpecification {
         List(
           "found version conflict(s) in library dependencies; some are suspected to be binary incompatible:",
           "",
-          "\t* com.typesafe.akka:akka-actor_2.10:2.3.0 (pvp) is selected over 2.1.4",
+          "\t* com.typesafe.akka:akka-actor_2.10:2.3.0 (pvp) is selected over 2.1.4 for {compile, test}",
           "\t    +- com.example:foo:0.1.0                              (depends on 2.1.4)",
           ""
-        )
+        ),
+      EvictionError(report, m, oldAkkaPvp).lines.mkString("\n"),
     )
   }
 
@@ -42,12 +43,13 @@ object EvictionErrorSpec extends BaseIvySpecification {
         List(
           "found version conflict(s) in library dependencies; some are suspected to be binary incompatible:",
           "",
-          "\t* com.typesafe.akka:akka-actor_2.10:2.3.4 (pvp) is selected over 2.1.4",
+          "\t* com.typesafe.akka:akka-actor_2.10:2.3.4 (pvp) is selected over 2.1.4 for {compile, test}",
           "\t    +- com.typesafe.akka:akka-remote_2.10:2.3.4           (depends on 2.3.4)",
           "\t    +- org.w3:banana-rdf_2.10:0.4                         (depends on 2.1.4)",
           "\t    +- org.w3:banana-sesame_2.10:0.4                      (depends on 2.1.4)",
           ""
-        )
+        ),
+      EvictionError(report, m, oldAkkaPvp).lines.mkString("\n"),
     )
   }
 
@@ -60,7 +62,7 @@ object EvictionErrorSpec extends BaseIvySpecification {
         List(
           "found version conflict(s) in library dependencies; some are suspected to be binary incompatible:",
           "",
-          "\t* com.typesafe.akka:akka-actor_2.10:2.3.4 (pvp?) is selected over 2.1.4",
+          "\t* com.typesafe.akka:akka-actor_2.10:2.3.4 (pvp?) is selected over 2.1.4 for {compile, test}",
           "\t    +- com.typesafe.akka:akka-remote_2.10:2.3.4           (depends on 2.3.4)",
           "\t    +- org.w3:banana-rdf_2.10:0.4                         (depends on 2.1.4)",
           "\t    +- org.w3:banana-sesame_2.10:0.4                      (depends on 2.1.4)",
@@ -78,14 +80,22 @@ object EvictionErrorSpec extends BaseIvySpecification {
         List(
           "found version conflict(s) in library dependencies; some are suspected to be binary incompatible:",
           "",
-          "\t* org.typelevel:cats-effect_2.13:3.0.0-M4 (early-semver) is selected over {2.0.0, 2.2.0}",
+          "\t* org.typelevel:cats-effect_2.13:3.0.0-M4 (early-semver) is selected over {2.0.0, 2.2.0} for compile",
           "\t    +- com.example:foo:0.1.0                              (depends on 3.0.0-M4)",
           "\t    +- co.fs2:fs2-core_2.13:2.4.5                         (depends on 2.2.0)",
           "\t    +- org.http4s:http4s-core_2.13:0.21.11                (depends on 2.2.0)",
           "\t    +- io.chrisdavenport:vault_2.13:2.0.0                 (depends on 2.0.0)",
           "\t    +- io.chrisdavenport:unique_2.13:2.0.0                (depends on 2.0.0)",
-          ""
-        )
+          "",
+          "\t* org.typelevel:cats-effect_2.13:3.0.0-M4 (early-semver) is selected over {2.0.0, 2.2.0} for test",
+          "\t    +- com.example:foo:0.1.0                              (depends on 2.2.0)",
+          "\t    +- co.fs2:fs2-core_2.13:2.4.5                         (depends on 2.2.0)",
+          "\t    +- org.http4s:http4s-core_2.13:0.21.11                (depends on 2.2.0)",
+          "\t    +- io.chrisdavenport:vault_2.13:2.0.0                 (depends on 2.0.0)",
+          "\t    +- io.chrisdavenport:unique_2.13:2.0.0                (depends on 2.0.0)",
+          "",
+        ),
+      EvictionError(report, m, Nil).lines.mkString("\n"),
     )
   }
 

--- a/ivy/src/test/scala/sbt/internal/librarymanagement/EvictionWarningSpec.scala
+++ b/ivy/src/test/scala/sbt/internal/librarymanagement/EvictionWarningSpec.scala
@@ -7,7 +7,8 @@ import sbt.librarymanagement.syntax._
 object EvictionWarningSpec extends BaseIvySpecification {
   // This is a specification to check the eviction warnings
 
-  import sbt.util.ShowLines._
+  import TestShowLines._
+
   def scalaVersionDeps = Vector(scala2102, akkaActor230)
 
   test("Eviction of non-overridden scala-library whose scalaVersion should be detected") {
@@ -310,17 +311,23 @@ object EvictionWarningSpec extends BaseIvySpecification {
   }
 
   def akkaActor214 =
-    ModuleID("com.typesafe.akka", "akka-actor", "2.1.4").withConfigurations(
-      Some("compile")
-    ) cross CrossVersion.binary
+    ModuleID("com.typesafe.akka", "akka-actor", "2.1.4")
+      .withConfigurations(
+        Some("compile")
+      )
+      .cross(CrossVersion.binary)
   def akkaActor230 =
-    ModuleID("com.typesafe.akka", "akka-actor", "2.3.0").withConfigurations(
-      Some("compile")
-    ) cross CrossVersion.binary
+    ModuleID("com.typesafe.akka", "akka-actor", "2.3.0")
+      .withConfigurations(
+        Some("compile")
+      )
+      .cross(CrossVersion.binary)
   def akkaActor234 =
-    ModuleID("com.typesafe.akka", "akka-actor", "2.3.4").withConfigurations(
-      Some("compile")
-    ) cross CrossVersion.binary
+    ModuleID("com.typesafe.akka", "akka-actor", "2.3.4")
+      .withConfigurations(
+        Some("compile")
+      )
+      .cross(CrossVersion.binary)
   def scala2102 =
     ModuleID("org.scala-lang", "scala-library", "2.10.2").withConfigurations(Some("compile"))
   def scala2103 =
@@ -335,22 +342,50 @@ object EvictionWarningSpec extends BaseIvySpecification {
       Some("compile")
     ) // uses commons-io 2.4
   def unfilteredUploads080 =
-    ModuleID("net.databinder", "unfiltered-uploads", "0.8.0").withConfigurations(
-      Some("compile")
-    ) cross CrossVersion.binary // uses commons-io 1.4
+    ModuleID("net.databinder", "unfiltered-uploads", "0.8.0")
+      .withConfigurations(
+        Some("compile")
+      )
+      .cross(CrossVersion.binary) // uses commons-io 1.4
   def bananaSesame04 =
-    ModuleID("org.w3", "banana-sesame", "0.4").withConfigurations(
-      Some("compile")
-    ) cross CrossVersion.binary // uses akka-actor 2.1.4
+    ModuleID("org.w3", "banana-sesame", "0.4")
+      .withConfigurations(
+        Some("compile")
+      )
+      .cross(CrossVersion.binary) // uses akka-actor 2.1.4
   def akkaRemote234 =
-    ModuleID("com.typesafe.akka", "akka-remote", "2.3.4").withConfigurations(
-      Some("compile")
-    ) cross CrossVersion.binary // uses akka-actor 2.3.4
+    ModuleID("com.typesafe.akka", "akka-remote", "2.3.4")
+      .withConfigurations(
+        Some("compile")
+      )
+      .cross(CrossVersion.binary) // uses akka-actor 2.3.4
 
   def fullOptions = EvictionWarningOptions.full
   def javaLibDirectDeps = Vector(commonsIo14, commonsIo24)
   def javaLibTransitiveDeps = Vector(unfilteredUploads080, bnfparser10)
   def scalaLibTransitiveDeps = Vector(scala2104, bananaSesame04, akkaRemote234)
+
+  // #6244: oauth2-oidc-sdk and nimbus-jose-jwt both depend on net.minidev:json-smart [1.3.1,2.3];
+  // resolution selects 2.3, which is within the range, so we must not report it as eviction.
+  def oauth2OidcSdk822 =
+    ModuleID("com.nimbusds", "oauth2-oidc-sdk", "8.22").withConfigurations(Some("compile"))
+  def nimbusJoseJwt8201 =
+    ModuleID("com.nimbusds", "nimbus-jose-jwt", "8.20.1").withConfigurations(Some("compile"))
+  def versionIntervalDeps6244 = Vector(oauth2OidcSdk822, nimbusJoseJwt8201)
+
+  test(
+    "When winner satisfies version range [1.3.1,2.3], should not report eviction for json-smart (fixes #6244)"
+  ) {
+    val m = module(defaultModuleId, versionIntervalDeps6244, Some("2.12.12"))
+    val report = ivyUpdate(m)
+    val warning = EvictionWarning(m, fullOptions, report)
+    val jsonSmartEviction =
+      warning.reportedEvictions.find(p => p.organization == "net.minidev" && p.name == "json-smart")
+    assert(
+      jsonSmartEviction.isEmpty,
+      s"#6244: json-smart 2.3 is within range [1.3.1,2.3], should not be reported as eviction. Got:\n${warning.lines.mkString("\n")}"
+    )
+  }
   def dummyScalaModuleInfo(v: String): ScalaModuleInfo =
     ScalaModuleInfo(
       scalaFullVersion = v,

--- a/ivy/src/test/scala/sbt/internal/librarymanagement/TestShowLines.scala
+++ b/ivy/src/test/scala/sbt/internal/librarymanagement/TestShowLines.scala
@@ -1,0 +1,12 @@
+package sbt
+package internal
+package librarymanagement
+
+import sbt.util.ShowLines
+
+object TestShowLines {
+  implicit class RichShowLines[A: ShowLines](a: A) {
+    def lines: Seq[String] =
+      implicitly[ShowLines[A]].showLines(a)
+  }
+}


### PR DESCRIPTION
* Add Test configuration to evictionWarningOptions
* Add Test configuration to default evictionWarningOptions
* Deduplicate eviction errors based on callers.
* Update eviction error test for semantic versioning.
* Group evictions by configuration and update test.